### PR TITLE
Add missing field discovered during testing

### DIFF
--- a/src/main/java/com/atlan/model/typedefs/CustomMetadataOptions.java
+++ b/src/main/java/com/atlan/model/typedefs/CustomMetadataOptions.java
@@ -28,4 +28,7 @@ public class CustomMetadataOptions extends AtlanObject {
 
     /** Indicates whether the custom metadata can be managed in the UI (false) or not (true). */
     String isLocked;
+
+    /** The id of the image used for the logo. */
+    String imageId;
 }


### PR DESCRIPTION
When trying to execute the following:
 ```
Atlan.setApiToken(System.getenv(“ATLAN_API_KEY”));
Atlan.setBaseUrl(System.getenv(“ATLAN_BASE_URL”));
 Entity glossary = Glossary.retrieveMinimal(“37e50bf7-abcb-4509-8155-c4894c05c9b9”);
```
Was getting the following error:
Caused by: com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException: Unrecognized field “imageId” (class com.atlan.model.typedefs.CustomMetadataOptions$CustomMetadataOptionsBuilderImpl), not marked as ignorable (5 known properties: “$fillValuesFrom”, “logoUrl”, “logoType”, “emoji”, “isLocked”])
This was because businessMetadataDefs returned contains the following:
```
“options”: {
        “imageId”: “0c9f6c0f-f764-4032-8380-b941b98dcd6d”,
        “logoType”: “image”,
        “emoji”: null
      },
```
Added the missing imageId field


