### PR TITLE
Fixes and additions

### DIFF
--- a/src/liveTest/java/com/atlan/generators/AbstractGenerator.java
+++ b/src/liveTest/java/com/atlan/generators/AbstractGenerator.java
@@ -115,7 +115,9 @@ public abstract class AbstractGenerator extends AtlanLiveTest {
             Map.entry("sourceReadPopularQueryRecordList", "sourceReadPopularQueryRecords"),
             Map.entry("sourceReadExpensiveQueryRecordList", "sourceReadExpensiveQueryRecords"),
             Map.entry("sourceReadSlowQueryRecordList", "sourceReadSlowQueryRecords"),
-            Map.entry("sourceQueryComputeCostRecordList", "sourceQueryComputeCostRecords"));
+            Map.entry("sourceQueryComputeCostRecordList", "sourceQueryComputeCostRecords"),
+            Map.entry("meanings", "assignedTerms"),
+            Map.entry("sqlAsset", "primarySqlAsset"));
 
     // Go ahead and create these types as non-abstract types, despite having
     // subtypes

--- a/src/liveTest/java/com/atlan/live/CustomMetadataTest.java
+++ b/src/liveTest/java/com/atlan/live/CustomMetadataTest.java
@@ -81,7 +81,10 @@ public class CustomMetadataTest extends AtlanLiveTest {
                         AttributeDef.of(CM_ATTR_IPR_MANDATORY, AtlanCustomAttributePrimitiveType.BOOLEAN, null, false))
                 .attributeDef(AttributeDef.of(CM_ATTR_IPR_DATE, AtlanCustomAttributePrimitiveType.DATE, null, false))
                 .attributeDef(AttributeDef.of(CM_ATTR_IPR_URL, AtlanCustomAttributePrimitiveType.URL, null, false))
-                .options(CustomMetadataOptions.builder().emoji("⚖️").build())
+                .options(CustomMetadataOptions.builder()
+                        .logoType("emoji")
+                        .emoji("⚖️")
+                        .build())
                 .build();
         CustomMetadataDef response = customMetadataDef.create();
         assertNotNull(response);
@@ -144,7 +147,10 @@ public class CustomMetadataTest extends AtlanLiveTest {
                         AttributeDef.of(CM_ATTR_RACI_INFORMED, AtlanCustomAttributePrimitiveType.GROUPS, null, true))
                 .attributeDef(
                         AttributeDef.of(CM_ATTR_RACI_EXTRA, AtlanCustomAttributePrimitiveType.STRING, null, false))
-                .options(CustomMetadataOptions.builder().emoji("\uD83D\uDC6A").build())
+                .options(CustomMetadataOptions.builder()
+                        .logoType("emoji")
+                        .emoji("\uD83D\uDC6A")
+                        .build())
                 .build();
         CustomMetadataDef response = customMetadataDef.create();
         assertNotNull(response);
@@ -216,7 +222,10 @@ public class CustomMetadataTest extends AtlanLiveTest {
                 .attributeDef(AttributeDef.of(CM_ATTR_QUALITY_SQL, AtlanCustomAttributePrimitiveType.SQL, null, false))
                 .attributeDef(AttributeDef.of(
                         CM_ATTR_QUALITY_TYPE, AtlanCustomAttributePrimitiveType.OPTIONS, CM_ENUM_DQ_TYPE, false))
-                .options(CustomMetadataOptions.builder().emoji("\uD83D\uDD16").build())
+                .options(CustomMetadataOptions.builder()
+                        .logoType("emoji")
+                        .emoji("\uD83D\uDD16")
+                        .build())
                 .build();
         CustomMetadataDef response = customMetadataDef.create();
         assertNotNull(response);

--- a/src/main/java/com/atlan/cache/CustomMetadataCache.java
+++ b/src/main/java/com/atlan/cache/CustomMetadataCache.java
@@ -57,7 +57,8 @@ public class CustomMetadataCache {
                 String attrId = attributeDef.getName();
                 String attrName = attributeDef.getDisplayName();
                 mapAttrIdToName.get(typeId).put(attrId, attrName);
-                if (attributeDef.getOptions().getIsArchived()) {
+                Boolean isArchived = attributeDef.getOptions().getIsArchived();
+                if (isArchived != null && isArchived) {
                     archivedAttrIds.put(attrId, attrName);
                 } else {
                     String existingId =

--- a/src/main/java/com/atlan/model/assets/AtlanQuery.java
+++ b/src/main/java/com/atlan/model/assets/AtlanQuery.java
@@ -79,12 +79,12 @@ public class AtlanQuery extends SQL {
     /** TBC */
     @Attribute
     @Singular
-    SortedSet<Table> tables;
+    SortedSet<Column> columns;
 
     /** TBC */
     @Attribute
     @Singular
-    SortedSet<Column> columns;
+    SortedSet<Table> tables;
 
     /** TBC */
     @Attribute

--- a/src/main/java/com/atlan/model/assets/BI.java
+++ b/src/main/java/com/atlan/model/assets/BI.java
@@ -20,6 +20,7 @@ import lombok.experimental.SuperBuilder;
     @JsonSubTypes.Type(value = Preset.class, name = Preset.TYPE_NAME),
     @JsonSubTypes.Type(value = Sigma.class, name = Sigma.TYPE_NAME),
     @JsonSubTypes.Type(value = Mode.class, name = Mode.TYPE_NAME),
+    @JsonSubTypes.Type(value = Qlik.class, name = Qlik.TYPE_NAME),
     @JsonSubTypes.Type(value = Tableau.class, name = Tableau.TYPE_NAME),
     @JsonSubTypes.Type(value = Looker.class, name = Looker.TYPE_NAME),
 })

--- a/src/main/java/com/atlan/model/assets/DbtSource.java
+++ b/src/main/java/com/atlan/model/assets/DbtSource.java
@@ -8,8 +8,10 @@ import com.atlan.exception.InvalidRequestException;
 import com.atlan.exception.NotFoundException;
 import com.atlan.model.enums.*;
 import com.atlan.model.relations.UniqueAttributes;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.SortedSet;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 
@@ -41,7 +43,13 @@ public class DbtSource extends Dbt {
 
     /** TBC */
     @Attribute
-    SQL sqlAsset;
+    @Singular
+    SortedSet<SQL> sqlAssets;
+
+    /** TBC */
+    @Attribute
+    @JsonProperty("sqlAsset")
+    SQL primarySqlAsset;
 
     /**
      * Reference to a DbtSource by GUID.

--- a/src/main/java/com/atlan/model/assets/Qlik.java
+++ b/src/main/java/com/atlan/model/assets/Qlik.java
@@ -1,0 +1,59 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import com.atlan.model.enums.*;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * TBC
+ */
+@Getter
+@Setter
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = QlikSpace.class, name = QlikSpace.TYPE_NAME),
+    @JsonSubTypes.Type(value = QlikApp.class, name = QlikApp.TYPE_NAME),
+    @JsonSubTypes.Type(value = QlikChart.class, name = QlikChart.TYPE_NAME),
+    @JsonSubTypes.Type(value = QlikDataset.class, name = QlikDataset.TYPE_NAME),
+    @JsonSubTypes.Type(value = QlikSheet.class, name = QlikSheet.TYPE_NAME),
+})
+public abstract class Qlik extends BI {
+
+    public static final String TYPE_NAME = "Qlik";
+
+    /** TBC */
+    @Attribute
+    String qlikId;
+
+    /** TBC */
+    @Attribute
+    String qlikQRI;
+
+    /** TBC */
+    @Attribute
+    String qlikSpaceId;
+
+    /** TBC */
+    @Attribute
+    String qlikSpaceQualifiedName;
+
+    /** TBC */
+    @Attribute
+    String qlikAppId;
+
+    /** TBC */
+    @Attribute
+    String qlikAppQualifiedName;
+
+    /** TBC */
+    @Attribute
+    String qlikOwnerId;
+
+    /** TBC */
+    @Attribute
+    Boolean qlikIsPublished;
+}

--- a/src/main/java/com/atlan/model/assets/QlikApp.java
+++ b/src/main/java/com/atlan/model/assets/QlikApp.java
@@ -1,0 +1,319 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import com.atlan.exception.AtlanException;
+import com.atlan.exception.ErrorCode;
+import com.atlan.exception.InvalidRequestException;
+import com.atlan.exception.NotFoundException;
+import com.atlan.model.enums.*;
+import com.atlan.model.relations.UniqueAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * TBC
+ */
+@Getter
+@Setter
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+public class QlikApp extends Qlik {
+    private static final long serialVersionUID = 2L;
+
+    public static final String TYPE_NAME = "QlikApp";
+
+    /** Fixed typeName for QlikApps. */
+    @Getter(onMethod_ = {@Override})
+    @Setter(onMethod_ = {@Override})
+    @Builder.Default
+    String typeName = TYPE_NAME;
+
+    /** TBC */
+    @Attribute
+    Boolean qlikHasSectionAccess;
+
+    /** TBC */
+    @Attribute
+    String qlikOriginAppId;
+
+    /** TBC */
+    @Attribute
+    Boolean qlikIsEncrypted;
+
+    /** TBC */
+    @Attribute
+    Boolean qlikIsDirectQueryMode;
+
+    /** TBC */
+    @Attribute
+    Long qlikAppStaticByteSize;
+
+    /** TBC */
+    @Attribute
+    QlikSpace qlikSpace;
+
+    /** TBC */
+    @Attribute
+    @Singular
+    SortedSet<QlikSheet> qlikSheets;
+
+    /**
+     * Reference to a QlikApp by GUID.
+     *
+     * @param guid the GUID of the QlikApp to reference
+     * @return reference to a QlikApp that can be used for defining a relationship to a QlikApp
+     */
+    public static QlikApp refByGuid(String guid) {
+        return QlikApp.builder().guid(guid).build();
+    }
+
+    /**
+     * Reference to a QlikApp by qualifiedName.
+     *
+     * @param qualifiedName the qualifiedName of the QlikApp to reference
+     * @return reference to a QlikApp that can be used for defining a relationship to a QlikApp
+     */
+    public static QlikApp refByQualifiedName(String qualifiedName) {
+        return QlikApp.builder()
+                .uniqueAttributes(
+                        UniqueAttributes.builder().qualifiedName(qualifiedName).build())
+                .build();
+    }
+
+    /**
+     * Builds the minimal object necessary to update a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param name of the QlikApp
+     * @return the minimal request necessary to update the QlikApp, as a builder
+     */
+    public static QlikAppBuilder<?, ?> updater(String qualifiedName, String name) {
+        return QlikApp.builder().qualifiedName(qualifiedName).name(name);
+    }
+
+    /**
+     * Builds the minimal object necessary to apply an update to a QlikApp, from a potentially
+     * more-complete QlikApp object.
+     *
+     * @return the minimal object necessary to update the QlikApp, as a builder
+     * @throws InvalidRequestException if any of the minimal set of required properties for QlikApp are not found in the initial object
+     */
+    @Override
+    public QlikAppBuilder<?, ?> trimToRequired() throws InvalidRequestException {
+        List<String> missing = new ArrayList<>();
+        if (this.getQualifiedName() == null || this.getQualifiedName().length() == 0) {
+            missing.add("qualifiedName");
+        }
+        if (this.getName() == null || this.getName().length() == 0) {
+            missing.add("name");
+        }
+        if (!missing.isEmpty()) {
+            throw new InvalidRequestException(
+                    ErrorCode.MISSING_REQUIRED_UPDATE_PARAM, "QlikApp", String.join(",", missing));
+        }
+        return updater(this.getQualifiedName(), this.getName());
+    }
+
+    /**
+     * Retrieves a QlikApp by its GUID, complete with all of its relationships.
+     *
+     * @param guid of the QlikApp to retrieve
+     * @return the requested full QlikApp, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikApp does not exist or the provided GUID is not a QlikApp
+     */
+    public static QlikApp retrieveByGuid(String guid) throws AtlanException {
+        Asset asset = Asset.retrieveFull(guid);
+        if (asset == null) {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, guid);
+        } else if (asset instanceof QlikApp) {
+            return (QlikApp) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_TYPE_REQUESTED, guid, "QlikApp");
+        }
+    }
+
+    /**
+     * Retrieves a QlikApp by its qualifiedName, complete with all of its relationships.
+     *
+     * @param qualifiedName of the QlikApp to retrieve
+     * @return the requested full QlikApp, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikApp does not exist
+     */
+    public static QlikApp retrieveByQualifiedName(String qualifiedName) throws AtlanException {
+        Asset asset = Asset.retrieveFull(TYPE_NAME, qualifiedName);
+        if (asset instanceof QlikApp) {
+            return (QlikApp) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_QN, qualifiedName, "QlikApp");
+        }
+    }
+
+    /**
+     * Restore the archived (soft-deleted) QlikApp to active.
+     *
+     * @param qualifiedName for the QlikApp
+     * @return true if the QlikApp is now active, and false otherwise
+     * @throws AtlanException on any API problems
+     */
+    public static boolean restore(String qualifiedName) throws AtlanException {
+        return Asset.restore(TYPE_NAME, qualifiedName);
+    }
+
+    /**
+     * Remove the system description from a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param name of the QlikApp
+     * @return the updated QlikApp, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp removeDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikApp) Asset.removeDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the user's description from a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param name of the QlikApp
+     * @return the updated QlikApp, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp removeUserDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikApp) Asset.removeUserDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the owners from a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param name of the QlikApp
+     * @return the updated QlikApp, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp removeOwners(String qualifiedName, String name) throws AtlanException {
+        return (QlikApp) Asset.removeOwners(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the certificate on a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param certificate to use
+     * @param message (optional) message, or null if no message
+     * @return the updated QlikApp, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp updateCertificate(String qualifiedName, AtlanCertificateStatus certificate, String message)
+            throws AtlanException {
+        return (QlikApp) Asset.updateCertificate(builder(), TYPE_NAME, qualifiedName, certificate, message);
+    }
+
+    /**
+     * Remove the certificate from a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param name of the QlikApp
+     * @return the updated QlikApp, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp removeCertificate(String qualifiedName, String name) throws AtlanException {
+        return (QlikApp) Asset.removeCertificate(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the announcement on a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param type type of announcement to set
+     * @param title (optional) title of the announcement to set (or null for no title)
+     * @param message (optional) message of the announcement to set (or null for no message)
+     * @return the result of the update, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp updateAnnouncement(
+            String qualifiedName, AtlanAnnouncementType type, String title, String message) throws AtlanException {
+        return (QlikApp) Asset.updateAnnouncement(builder(), TYPE_NAME, qualifiedName, type, title, message);
+    }
+
+    /**
+     * Remove the announcement from a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param name of the QlikApp
+     * @return the updated QlikApp, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp removeAnnouncement(String qualifiedName, String name) throws AtlanException {
+        return (QlikApp) Asset.removeAnnouncement(updater(qualifiedName, name));
+    }
+
+    /**
+     * Add classifications to a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param classificationNames human-readable names of the classifications to add
+     * @throws AtlanException on any API problems, or if any of the classifications already exist on the QlikApp
+     */
+    public static void addClassifications(String qualifiedName, List<String> classificationNames)
+            throws AtlanException {
+        Asset.addClassifications(TYPE_NAME, qualifiedName, classificationNames);
+    }
+
+    /**
+     * Remove a classification from a QlikApp.
+     *
+     * @param qualifiedName of the QlikApp
+     * @param classificationName human-readable name of the classification to remove
+     * @throws AtlanException on any API problems, or if the classification does not exist on the QlikApp
+     */
+    public static void removeClassification(String qualifiedName, String classificationName) throws AtlanException {
+        Asset.removeClassification(TYPE_NAME, qualifiedName, classificationName);
+    }
+
+    /**
+     * Replace the terms linked to the QlikApp.
+     *
+     * @param qualifiedName for the QlikApp
+     * @param name human-readable name of the QlikApp
+     * @param terms the list of terms to replace on the QlikApp, or null to remove all terms from the QlikApp
+     * @return the QlikApp that was updated (note that it will NOT contain details of the replaced terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp replaceTerms(String qualifiedName, String name, List<GlossaryTerm> terms)
+            throws AtlanException {
+        return (QlikApp) Asset.replaceTerms(updater(qualifiedName, name), terms);
+    }
+
+    /**
+     * Link additional terms to the QlikApp, without replacing existing terms linked to the QlikApp.
+     * Note: this operation must make two API calls — one to retrieve the QlikApp's existing terms,
+     * and a second to append the new terms.
+     *
+     * @param qualifiedName for the QlikApp
+     * @param terms the list of terms to append to the QlikApp
+     * @return the QlikApp that was updated  (note that it will NOT contain details of the appended terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp appendTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikApp) Asset.appendTerms(TYPE_NAME, qualifiedName, terms);
+    }
+
+    /**
+     * Remove terms from a QlikApp, without replacing all existing terms linked to the QlikApp.
+     * Note: this operation must make two API calls — one to retrieve the QlikApp's existing terms,
+     * and a second to remove the provided terms.
+     *
+     * @param qualifiedName for the QlikApp
+     * @param terms the list of terms to remove from the QlikApp, which must be referenced by GUID
+     * @return the QlikApp that was updated (note that it will NOT contain details of the resulting terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikApp removeTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikApp) Asset.removeTerms(TYPE_NAME, qualifiedName, terms);
+    }
+}

--- a/src/main/java/com/atlan/model/assets/QlikChart.java
+++ b/src/main/java/com/atlan/model/assets/QlikChart.java
@@ -1,0 +1,309 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import com.atlan.exception.AtlanException;
+import com.atlan.exception.ErrorCode;
+import com.atlan.exception.InvalidRequestException;
+import com.atlan.exception.NotFoundException;
+import com.atlan.model.enums.*;
+import com.atlan.model.relations.UniqueAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * TBC
+ */
+@Getter
+@Setter
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+public class QlikChart extends Qlik {
+    private static final long serialVersionUID = 2L;
+
+    public static final String TYPE_NAME = "QlikChart";
+
+    /** Fixed typeName for QlikCharts. */
+    @Getter(onMethod_ = {@Override})
+    @Setter(onMethod_ = {@Override})
+    @Builder.Default
+    String typeName = TYPE_NAME;
+
+    /** TBC */
+    @Attribute
+    String qlikChartSubtitle;
+
+    /** TBC */
+    @Attribute
+    String qlikChartFootnote;
+
+    /** TBC */
+    @Attribute
+    String qlikChartOrientation;
+
+    /** TBC */
+    @Attribute
+    String qlikChartType;
+
+    /** TBC */
+    @Attribute
+    QlikSheet qlikSheet;
+
+    /**
+     * Reference to a QlikChart by GUID.
+     *
+     * @param guid the GUID of the QlikChart to reference
+     * @return reference to a QlikChart that can be used for defining a relationship to a QlikChart
+     */
+    public static QlikChart refByGuid(String guid) {
+        return QlikChart.builder().guid(guid).build();
+    }
+
+    /**
+     * Reference to a QlikChart by qualifiedName.
+     *
+     * @param qualifiedName the qualifiedName of the QlikChart to reference
+     * @return reference to a QlikChart that can be used for defining a relationship to a QlikChart
+     */
+    public static QlikChart refByQualifiedName(String qualifiedName) {
+        return QlikChart.builder()
+                .uniqueAttributes(
+                        UniqueAttributes.builder().qualifiedName(qualifiedName).build())
+                .build();
+    }
+
+    /**
+     * Builds the minimal object necessary to update a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param name of the QlikChart
+     * @return the minimal request necessary to update the QlikChart, as a builder
+     */
+    public static QlikChartBuilder<?, ?> updater(String qualifiedName, String name) {
+        return QlikChart.builder().qualifiedName(qualifiedName).name(name);
+    }
+
+    /**
+     * Builds the minimal object necessary to apply an update to a QlikChart, from a potentially
+     * more-complete QlikChart object.
+     *
+     * @return the minimal object necessary to update the QlikChart, as a builder
+     * @throws InvalidRequestException if any of the minimal set of required properties for QlikChart are not found in the initial object
+     */
+    @Override
+    public QlikChartBuilder<?, ?> trimToRequired() throws InvalidRequestException {
+        List<String> missing = new ArrayList<>();
+        if (this.getQualifiedName() == null || this.getQualifiedName().length() == 0) {
+            missing.add("qualifiedName");
+        }
+        if (this.getName() == null || this.getName().length() == 0) {
+            missing.add("name");
+        }
+        if (!missing.isEmpty()) {
+            throw new InvalidRequestException(
+                    ErrorCode.MISSING_REQUIRED_UPDATE_PARAM, "QlikChart", String.join(",", missing));
+        }
+        return updater(this.getQualifiedName(), this.getName());
+    }
+
+    /**
+     * Retrieves a QlikChart by its GUID, complete with all of its relationships.
+     *
+     * @param guid of the QlikChart to retrieve
+     * @return the requested full QlikChart, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikChart does not exist or the provided GUID is not a QlikChart
+     */
+    public static QlikChart retrieveByGuid(String guid) throws AtlanException {
+        Asset asset = Asset.retrieveFull(guid);
+        if (asset == null) {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, guid);
+        } else if (asset instanceof QlikChart) {
+            return (QlikChart) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_TYPE_REQUESTED, guid, "QlikChart");
+        }
+    }
+
+    /**
+     * Retrieves a QlikChart by its qualifiedName, complete with all of its relationships.
+     *
+     * @param qualifiedName of the QlikChart to retrieve
+     * @return the requested full QlikChart, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikChart does not exist
+     */
+    public static QlikChart retrieveByQualifiedName(String qualifiedName) throws AtlanException {
+        Asset asset = Asset.retrieveFull(TYPE_NAME, qualifiedName);
+        if (asset instanceof QlikChart) {
+            return (QlikChart) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_QN, qualifiedName, "QlikChart");
+        }
+    }
+
+    /**
+     * Restore the archived (soft-deleted) QlikChart to active.
+     *
+     * @param qualifiedName for the QlikChart
+     * @return true if the QlikChart is now active, and false otherwise
+     * @throws AtlanException on any API problems
+     */
+    public static boolean restore(String qualifiedName) throws AtlanException {
+        return Asset.restore(TYPE_NAME, qualifiedName);
+    }
+
+    /**
+     * Remove the system description from a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param name of the QlikChart
+     * @return the updated QlikChart, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart removeDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikChart) Asset.removeDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the user's description from a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param name of the QlikChart
+     * @return the updated QlikChart, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart removeUserDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikChart) Asset.removeUserDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the owners from a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param name of the QlikChart
+     * @return the updated QlikChart, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart removeOwners(String qualifiedName, String name) throws AtlanException {
+        return (QlikChart) Asset.removeOwners(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the certificate on a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param certificate to use
+     * @param message (optional) message, or null if no message
+     * @return the updated QlikChart, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart updateCertificate(String qualifiedName, AtlanCertificateStatus certificate, String message)
+            throws AtlanException {
+        return (QlikChart) Asset.updateCertificate(builder(), TYPE_NAME, qualifiedName, certificate, message);
+    }
+
+    /**
+     * Remove the certificate from a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param name of the QlikChart
+     * @return the updated QlikChart, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart removeCertificate(String qualifiedName, String name) throws AtlanException {
+        return (QlikChart) Asset.removeCertificate(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the announcement on a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param type type of announcement to set
+     * @param title (optional) title of the announcement to set (or null for no title)
+     * @param message (optional) message of the announcement to set (or null for no message)
+     * @return the result of the update, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart updateAnnouncement(
+            String qualifiedName, AtlanAnnouncementType type, String title, String message) throws AtlanException {
+        return (QlikChart) Asset.updateAnnouncement(builder(), TYPE_NAME, qualifiedName, type, title, message);
+    }
+
+    /**
+     * Remove the announcement from a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param name of the QlikChart
+     * @return the updated QlikChart, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart removeAnnouncement(String qualifiedName, String name) throws AtlanException {
+        return (QlikChart) Asset.removeAnnouncement(updater(qualifiedName, name));
+    }
+
+    /**
+     * Add classifications to a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param classificationNames human-readable names of the classifications to add
+     * @throws AtlanException on any API problems, or if any of the classifications already exist on the QlikChart
+     */
+    public static void addClassifications(String qualifiedName, List<String> classificationNames)
+            throws AtlanException {
+        Asset.addClassifications(TYPE_NAME, qualifiedName, classificationNames);
+    }
+
+    /**
+     * Remove a classification from a QlikChart.
+     *
+     * @param qualifiedName of the QlikChart
+     * @param classificationName human-readable name of the classification to remove
+     * @throws AtlanException on any API problems, or if the classification does not exist on the QlikChart
+     */
+    public static void removeClassification(String qualifiedName, String classificationName) throws AtlanException {
+        Asset.removeClassification(TYPE_NAME, qualifiedName, classificationName);
+    }
+
+    /**
+     * Replace the terms linked to the QlikChart.
+     *
+     * @param qualifiedName for the QlikChart
+     * @param name human-readable name of the QlikChart
+     * @param terms the list of terms to replace on the QlikChart, or null to remove all terms from the QlikChart
+     * @return the QlikChart that was updated (note that it will NOT contain details of the replaced terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart replaceTerms(String qualifiedName, String name, List<GlossaryTerm> terms)
+            throws AtlanException {
+        return (QlikChart) Asset.replaceTerms(updater(qualifiedName, name), terms);
+    }
+
+    /**
+     * Link additional terms to the QlikChart, without replacing existing terms linked to the QlikChart.
+     * Note: this operation must make two API calls — one to retrieve the QlikChart's existing terms,
+     * and a second to append the new terms.
+     *
+     * @param qualifiedName for the QlikChart
+     * @param terms the list of terms to append to the QlikChart
+     * @return the QlikChart that was updated  (note that it will NOT contain details of the appended terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart appendTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikChart) Asset.appendTerms(TYPE_NAME, qualifiedName, terms);
+    }
+
+    /**
+     * Remove terms from a QlikChart, without replacing all existing terms linked to the QlikChart.
+     * Note: this operation must make two API calls — one to retrieve the QlikChart's existing terms,
+     * and a second to remove the provided terms.
+     *
+     * @param qualifiedName for the QlikChart
+     * @param terms the list of terms to remove from the QlikChart, which must be referenced by GUID
+     * @return the QlikChart that was updated (note that it will NOT contain details of the resulting terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikChart removeTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikChart) Asset.removeTerms(TYPE_NAME, qualifiedName, terms);
+    }
+}

--- a/src/main/java/com/atlan/model/assets/QlikDataset.java
+++ b/src/main/java/com/atlan/model/assets/QlikDataset.java
@@ -1,0 +1,309 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import com.atlan.exception.AtlanException;
+import com.atlan.exception.ErrorCode;
+import com.atlan.exception.InvalidRequestException;
+import com.atlan.exception.NotFoundException;
+import com.atlan.model.enums.*;
+import com.atlan.model.relations.UniqueAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * TBC
+ */
+@Getter
+@Setter
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+public class QlikDataset extends Qlik {
+    private static final long serialVersionUID = 2L;
+
+    public static final String TYPE_NAME = "QlikDataset";
+
+    /** Fixed typeName for QlikDatasets. */
+    @Getter(onMethod_ = {@Override})
+    @Setter(onMethod_ = {@Override})
+    @Builder.Default
+    String typeName = TYPE_NAME;
+
+    /** TBC */
+    @Attribute
+    String qlikDatasetTechnicalName;
+
+    /** TBC */
+    @Attribute
+    String qlikDatasetType;
+
+    /** TBC */
+    @Attribute
+    String qlikDatasetUri;
+
+    /** TBC */
+    @Attribute
+    String qlikDatasetSubtype;
+
+    /** TBC */
+    @Attribute
+    QlikSpace qlikSpace;
+
+    /**
+     * Reference to a QlikDataset by GUID.
+     *
+     * @param guid the GUID of the QlikDataset to reference
+     * @return reference to a QlikDataset that can be used for defining a relationship to a QlikDataset
+     */
+    public static QlikDataset refByGuid(String guid) {
+        return QlikDataset.builder().guid(guid).build();
+    }
+
+    /**
+     * Reference to a QlikDataset by qualifiedName.
+     *
+     * @param qualifiedName the qualifiedName of the QlikDataset to reference
+     * @return reference to a QlikDataset that can be used for defining a relationship to a QlikDataset
+     */
+    public static QlikDataset refByQualifiedName(String qualifiedName) {
+        return QlikDataset.builder()
+                .uniqueAttributes(
+                        UniqueAttributes.builder().qualifiedName(qualifiedName).build())
+                .build();
+    }
+
+    /**
+     * Builds the minimal object necessary to update a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param name of the QlikDataset
+     * @return the minimal request necessary to update the QlikDataset, as a builder
+     */
+    public static QlikDatasetBuilder<?, ?> updater(String qualifiedName, String name) {
+        return QlikDataset.builder().qualifiedName(qualifiedName).name(name);
+    }
+
+    /**
+     * Builds the minimal object necessary to apply an update to a QlikDataset, from a potentially
+     * more-complete QlikDataset object.
+     *
+     * @return the minimal object necessary to update the QlikDataset, as a builder
+     * @throws InvalidRequestException if any of the minimal set of required properties for QlikDataset are not found in the initial object
+     */
+    @Override
+    public QlikDatasetBuilder<?, ?> trimToRequired() throws InvalidRequestException {
+        List<String> missing = new ArrayList<>();
+        if (this.getQualifiedName() == null || this.getQualifiedName().length() == 0) {
+            missing.add("qualifiedName");
+        }
+        if (this.getName() == null || this.getName().length() == 0) {
+            missing.add("name");
+        }
+        if (!missing.isEmpty()) {
+            throw new InvalidRequestException(
+                    ErrorCode.MISSING_REQUIRED_UPDATE_PARAM, "QlikDataset", String.join(",", missing));
+        }
+        return updater(this.getQualifiedName(), this.getName());
+    }
+
+    /**
+     * Retrieves a QlikDataset by its GUID, complete with all of its relationships.
+     *
+     * @param guid of the QlikDataset to retrieve
+     * @return the requested full QlikDataset, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikDataset does not exist or the provided GUID is not a QlikDataset
+     */
+    public static QlikDataset retrieveByGuid(String guid) throws AtlanException {
+        Asset asset = Asset.retrieveFull(guid);
+        if (asset == null) {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, guid);
+        } else if (asset instanceof QlikDataset) {
+            return (QlikDataset) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_TYPE_REQUESTED, guid, "QlikDataset");
+        }
+    }
+
+    /**
+     * Retrieves a QlikDataset by its qualifiedName, complete with all of its relationships.
+     *
+     * @param qualifiedName of the QlikDataset to retrieve
+     * @return the requested full QlikDataset, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikDataset does not exist
+     */
+    public static QlikDataset retrieveByQualifiedName(String qualifiedName) throws AtlanException {
+        Asset asset = Asset.retrieveFull(TYPE_NAME, qualifiedName);
+        if (asset instanceof QlikDataset) {
+            return (QlikDataset) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_QN, qualifiedName, "QlikDataset");
+        }
+    }
+
+    /**
+     * Restore the archived (soft-deleted) QlikDataset to active.
+     *
+     * @param qualifiedName for the QlikDataset
+     * @return true if the QlikDataset is now active, and false otherwise
+     * @throws AtlanException on any API problems
+     */
+    public static boolean restore(String qualifiedName) throws AtlanException {
+        return Asset.restore(TYPE_NAME, qualifiedName);
+    }
+
+    /**
+     * Remove the system description from a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param name of the QlikDataset
+     * @return the updated QlikDataset, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset removeDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikDataset) Asset.removeDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the user's description from a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param name of the QlikDataset
+     * @return the updated QlikDataset, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset removeUserDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikDataset) Asset.removeUserDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the owners from a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param name of the QlikDataset
+     * @return the updated QlikDataset, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset removeOwners(String qualifiedName, String name) throws AtlanException {
+        return (QlikDataset) Asset.removeOwners(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the certificate on a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param certificate to use
+     * @param message (optional) message, or null if no message
+     * @return the updated QlikDataset, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset updateCertificate(
+            String qualifiedName, AtlanCertificateStatus certificate, String message) throws AtlanException {
+        return (QlikDataset) Asset.updateCertificate(builder(), TYPE_NAME, qualifiedName, certificate, message);
+    }
+
+    /**
+     * Remove the certificate from a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param name of the QlikDataset
+     * @return the updated QlikDataset, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset removeCertificate(String qualifiedName, String name) throws AtlanException {
+        return (QlikDataset) Asset.removeCertificate(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the announcement on a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param type type of announcement to set
+     * @param title (optional) title of the announcement to set (or null for no title)
+     * @param message (optional) message of the announcement to set (or null for no message)
+     * @return the result of the update, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset updateAnnouncement(
+            String qualifiedName, AtlanAnnouncementType type, String title, String message) throws AtlanException {
+        return (QlikDataset) Asset.updateAnnouncement(builder(), TYPE_NAME, qualifiedName, type, title, message);
+    }
+
+    /**
+     * Remove the announcement from a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param name of the QlikDataset
+     * @return the updated QlikDataset, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset removeAnnouncement(String qualifiedName, String name) throws AtlanException {
+        return (QlikDataset) Asset.removeAnnouncement(updater(qualifiedName, name));
+    }
+
+    /**
+     * Add classifications to a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param classificationNames human-readable names of the classifications to add
+     * @throws AtlanException on any API problems, or if any of the classifications already exist on the QlikDataset
+     */
+    public static void addClassifications(String qualifiedName, List<String> classificationNames)
+            throws AtlanException {
+        Asset.addClassifications(TYPE_NAME, qualifiedName, classificationNames);
+    }
+
+    /**
+     * Remove a classification from a QlikDataset.
+     *
+     * @param qualifiedName of the QlikDataset
+     * @param classificationName human-readable name of the classification to remove
+     * @throws AtlanException on any API problems, or if the classification does not exist on the QlikDataset
+     */
+    public static void removeClassification(String qualifiedName, String classificationName) throws AtlanException {
+        Asset.removeClassification(TYPE_NAME, qualifiedName, classificationName);
+    }
+
+    /**
+     * Replace the terms linked to the QlikDataset.
+     *
+     * @param qualifiedName for the QlikDataset
+     * @param name human-readable name of the QlikDataset
+     * @param terms the list of terms to replace on the QlikDataset, or null to remove all terms from the QlikDataset
+     * @return the QlikDataset that was updated (note that it will NOT contain details of the replaced terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset replaceTerms(String qualifiedName, String name, List<GlossaryTerm> terms)
+            throws AtlanException {
+        return (QlikDataset) Asset.replaceTerms(updater(qualifiedName, name), terms);
+    }
+
+    /**
+     * Link additional terms to the QlikDataset, without replacing existing terms linked to the QlikDataset.
+     * Note: this operation must make two API calls — one to retrieve the QlikDataset's existing terms,
+     * and a second to append the new terms.
+     *
+     * @param qualifiedName for the QlikDataset
+     * @param terms the list of terms to append to the QlikDataset
+     * @return the QlikDataset that was updated  (note that it will NOT contain details of the appended terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset appendTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikDataset) Asset.appendTerms(TYPE_NAME, qualifiedName, terms);
+    }
+
+    /**
+     * Remove terms from a QlikDataset, without replacing all existing terms linked to the QlikDataset.
+     * Note: this operation must make two API calls — one to retrieve the QlikDataset's existing terms,
+     * and a second to remove the provided terms.
+     *
+     * @param qualifiedName for the QlikDataset
+     * @param terms the list of terms to remove from the QlikDataset, which must be referenced by GUID
+     * @return the QlikDataset that was updated (note that it will NOT contain details of the resulting terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikDataset removeTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikDataset) Asset.removeTerms(TYPE_NAME, qualifiedName, terms);
+    }
+}

--- a/src/main/java/com/atlan/model/assets/QlikSheet.java
+++ b/src/main/java/com/atlan/model/assets/QlikSheet.java
@@ -1,0 +1,303 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import com.atlan.exception.AtlanException;
+import com.atlan.exception.ErrorCode;
+import com.atlan.exception.InvalidRequestException;
+import com.atlan.exception.NotFoundException;
+import com.atlan.model.enums.*;
+import com.atlan.model.relations.UniqueAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * TBC
+ */
+@Getter
+@Setter
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+public class QlikSheet extends Qlik {
+    private static final long serialVersionUID = 2L;
+
+    public static final String TYPE_NAME = "QlikSheet";
+
+    /** Fixed typeName for QlikSheets. */
+    @Getter(onMethod_ = {@Override})
+    @Setter(onMethod_ = {@Override})
+    @Builder.Default
+    String typeName = TYPE_NAME;
+
+    /** TBC */
+    @Attribute
+    Boolean qlikSheetIsApproved;
+
+    /** TBC */
+    @Attribute
+    QlikApp qlikApp;
+
+    /** TBC */
+    @Attribute
+    @Singular
+    SortedSet<QlikChart> qlikCharts;
+
+    /**
+     * Reference to a QlikSheet by GUID.
+     *
+     * @param guid the GUID of the QlikSheet to reference
+     * @return reference to a QlikSheet that can be used for defining a relationship to a QlikSheet
+     */
+    public static QlikSheet refByGuid(String guid) {
+        return QlikSheet.builder().guid(guid).build();
+    }
+
+    /**
+     * Reference to a QlikSheet by qualifiedName.
+     *
+     * @param qualifiedName the qualifiedName of the QlikSheet to reference
+     * @return reference to a QlikSheet that can be used for defining a relationship to a QlikSheet
+     */
+    public static QlikSheet refByQualifiedName(String qualifiedName) {
+        return QlikSheet.builder()
+                .uniqueAttributes(
+                        UniqueAttributes.builder().qualifiedName(qualifiedName).build())
+                .build();
+    }
+
+    /**
+     * Builds the minimal object necessary to update a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param name of the QlikSheet
+     * @return the minimal request necessary to update the QlikSheet, as a builder
+     */
+    public static QlikSheetBuilder<?, ?> updater(String qualifiedName, String name) {
+        return QlikSheet.builder().qualifiedName(qualifiedName).name(name);
+    }
+
+    /**
+     * Builds the minimal object necessary to apply an update to a QlikSheet, from a potentially
+     * more-complete QlikSheet object.
+     *
+     * @return the minimal object necessary to update the QlikSheet, as a builder
+     * @throws InvalidRequestException if any of the minimal set of required properties for QlikSheet are not found in the initial object
+     */
+    @Override
+    public QlikSheetBuilder<?, ?> trimToRequired() throws InvalidRequestException {
+        List<String> missing = new ArrayList<>();
+        if (this.getQualifiedName() == null || this.getQualifiedName().length() == 0) {
+            missing.add("qualifiedName");
+        }
+        if (this.getName() == null || this.getName().length() == 0) {
+            missing.add("name");
+        }
+        if (!missing.isEmpty()) {
+            throw new InvalidRequestException(
+                    ErrorCode.MISSING_REQUIRED_UPDATE_PARAM, "QlikSheet", String.join(",", missing));
+        }
+        return updater(this.getQualifiedName(), this.getName());
+    }
+
+    /**
+     * Retrieves a QlikSheet by its GUID, complete with all of its relationships.
+     *
+     * @param guid of the QlikSheet to retrieve
+     * @return the requested full QlikSheet, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikSheet does not exist or the provided GUID is not a QlikSheet
+     */
+    public static QlikSheet retrieveByGuid(String guid) throws AtlanException {
+        Asset asset = Asset.retrieveFull(guid);
+        if (asset == null) {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, guid);
+        } else if (asset instanceof QlikSheet) {
+            return (QlikSheet) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_TYPE_REQUESTED, guid, "QlikSheet");
+        }
+    }
+
+    /**
+     * Retrieves a QlikSheet by its qualifiedName, complete with all of its relationships.
+     *
+     * @param qualifiedName of the QlikSheet to retrieve
+     * @return the requested full QlikSheet, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikSheet does not exist
+     */
+    public static QlikSheet retrieveByQualifiedName(String qualifiedName) throws AtlanException {
+        Asset asset = Asset.retrieveFull(TYPE_NAME, qualifiedName);
+        if (asset instanceof QlikSheet) {
+            return (QlikSheet) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_QN, qualifiedName, "QlikSheet");
+        }
+    }
+
+    /**
+     * Restore the archived (soft-deleted) QlikSheet to active.
+     *
+     * @param qualifiedName for the QlikSheet
+     * @return true if the QlikSheet is now active, and false otherwise
+     * @throws AtlanException on any API problems
+     */
+    public static boolean restore(String qualifiedName) throws AtlanException {
+        return Asset.restore(TYPE_NAME, qualifiedName);
+    }
+
+    /**
+     * Remove the system description from a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param name of the QlikSheet
+     * @return the updated QlikSheet, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet removeDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikSheet) Asset.removeDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the user's description from a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param name of the QlikSheet
+     * @return the updated QlikSheet, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet removeUserDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikSheet) Asset.removeUserDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the owners from a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param name of the QlikSheet
+     * @return the updated QlikSheet, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet removeOwners(String qualifiedName, String name) throws AtlanException {
+        return (QlikSheet) Asset.removeOwners(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the certificate on a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param certificate to use
+     * @param message (optional) message, or null if no message
+     * @return the updated QlikSheet, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet updateCertificate(String qualifiedName, AtlanCertificateStatus certificate, String message)
+            throws AtlanException {
+        return (QlikSheet) Asset.updateCertificate(builder(), TYPE_NAME, qualifiedName, certificate, message);
+    }
+
+    /**
+     * Remove the certificate from a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param name of the QlikSheet
+     * @return the updated QlikSheet, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet removeCertificate(String qualifiedName, String name) throws AtlanException {
+        return (QlikSheet) Asset.removeCertificate(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the announcement on a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param type type of announcement to set
+     * @param title (optional) title of the announcement to set (or null for no title)
+     * @param message (optional) message of the announcement to set (or null for no message)
+     * @return the result of the update, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet updateAnnouncement(
+            String qualifiedName, AtlanAnnouncementType type, String title, String message) throws AtlanException {
+        return (QlikSheet) Asset.updateAnnouncement(builder(), TYPE_NAME, qualifiedName, type, title, message);
+    }
+
+    /**
+     * Remove the announcement from a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param name of the QlikSheet
+     * @return the updated QlikSheet, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet removeAnnouncement(String qualifiedName, String name) throws AtlanException {
+        return (QlikSheet) Asset.removeAnnouncement(updater(qualifiedName, name));
+    }
+
+    /**
+     * Add classifications to a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param classificationNames human-readable names of the classifications to add
+     * @throws AtlanException on any API problems, or if any of the classifications already exist on the QlikSheet
+     */
+    public static void addClassifications(String qualifiedName, List<String> classificationNames)
+            throws AtlanException {
+        Asset.addClassifications(TYPE_NAME, qualifiedName, classificationNames);
+    }
+
+    /**
+     * Remove a classification from a QlikSheet.
+     *
+     * @param qualifiedName of the QlikSheet
+     * @param classificationName human-readable name of the classification to remove
+     * @throws AtlanException on any API problems, or if the classification does not exist on the QlikSheet
+     */
+    public static void removeClassification(String qualifiedName, String classificationName) throws AtlanException {
+        Asset.removeClassification(TYPE_NAME, qualifiedName, classificationName);
+    }
+
+    /**
+     * Replace the terms linked to the QlikSheet.
+     *
+     * @param qualifiedName for the QlikSheet
+     * @param name human-readable name of the QlikSheet
+     * @param terms the list of terms to replace on the QlikSheet, or null to remove all terms from the QlikSheet
+     * @return the QlikSheet that was updated (note that it will NOT contain details of the replaced terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet replaceTerms(String qualifiedName, String name, List<GlossaryTerm> terms)
+            throws AtlanException {
+        return (QlikSheet) Asset.replaceTerms(updater(qualifiedName, name), terms);
+    }
+
+    /**
+     * Link additional terms to the QlikSheet, without replacing existing terms linked to the QlikSheet.
+     * Note: this operation must make two API calls — one to retrieve the QlikSheet's existing terms,
+     * and a second to append the new terms.
+     *
+     * @param qualifiedName for the QlikSheet
+     * @param terms the list of terms to append to the QlikSheet
+     * @return the QlikSheet that was updated  (note that it will NOT contain details of the appended terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet appendTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikSheet) Asset.appendTerms(TYPE_NAME, qualifiedName, terms);
+    }
+
+    /**
+     * Remove terms from a QlikSheet, without replacing all existing terms linked to the QlikSheet.
+     * Note: this operation must make two API calls — one to retrieve the QlikSheet's existing terms,
+     * and a second to remove the provided terms.
+     *
+     * @param qualifiedName for the QlikSheet
+     * @param terms the list of terms to remove from the QlikSheet, which must be referenced by GUID
+     * @return the QlikSheet that was updated (note that it will NOT contain details of the resulting terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSheet removeTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikSheet) Asset.removeTerms(TYPE_NAME, qualifiedName, terms);
+    }
+}

--- a/src/main/java/com/atlan/model/assets/QlikSpace.java
+++ b/src/main/java/com/atlan/model/assets/QlikSpace.java
@@ -1,0 +1,304 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import com.atlan.exception.AtlanException;
+import com.atlan.exception.ErrorCode;
+import com.atlan.exception.InvalidRequestException;
+import com.atlan.exception.NotFoundException;
+import com.atlan.model.enums.*;
+import com.atlan.model.relations.UniqueAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.SortedSet;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * TBC
+ */
+@Getter
+@Setter
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+public class QlikSpace extends Qlik {
+    private static final long serialVersionUID = 2L;
+
+    public static final String TYPE_NAME = "QlikSpace";
+
+    /** Fixed typeName for QlikSpaces. */
+    @Getter(onMethod_ = {@Override})
+    @Setter(onMethod_ = {@Override})
+    @Builder.Default
+    String typeName = TYPE_NAME;
+
+    /** TBC */
+    @Attribute
+    String qlikSpaceType;
+
+    /** TBC */
+    @Attribute
+    @Singular
+    SortedSet<QlikDataset> qlikDatasets;
+
+    /** TBC */
+    @Attribute
+    @Singular
+    SortedSet<QlikApp> qlikApps;
+
+    /**
+     * Reference to a QlikSpace by GUID.
+     *
+     * @param guid the GUID of the QlikSpace to reference
+     * @return reference to a QlikSpace that can be used for defining a relationship to a QlikSpace
+     */
+    public static QlikSpace refByGuid(String guid) {
+        return QlikSpace.builder().guid(guid).build();
+    }
+
+    /**
+     * Reference to a QlikSpace by qualifiedName.
+     *
+     * @param qualifiedName the qualifiedName of the QlikSpace to reference
+     * @return reference to a QlikSpace that can be used for defining a relationship to a QlikSpace
+     */
+    public static QlikSpace refByQualifiedName(String qualifiedName) {
+        return QlikSpace.builder()
+                .uniqueAttributes(
+                        UniqueAttributes.builder().qualifiedName(qualifiedName).build())
+                .build();
+    }
+
+    /**
+     * Builds the minimal object necessary to update a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param name of the QlikSpace
+     * @return the minimal request necessary to update the QlikSpace, as a builder
+     */
+    public static QlikSpaceBuilder<?, ?> updater(String qualifiedName, String name) {
+        return QlikSpace.builder().qualifiedName(qualifiedName).name(name);
+    }
+
+    /**
+     * Builds the minimal object necessary to apply an update to a QlikSpace, from a potentially
+     * more-complete QlikSpace object.
+     *
+     * @return the minimal object necessary to update the QlikSpace, as a builder
+     * @throws InvalidRequestException if any of the minimal set of required properties for QlikSpace are not found in the initial object
+     */
+    @Override
+    public QlikSpaceBuilder<?, ?> trimToRequired() throws InvalidRequestException {
+        List<String> missing = new ArrayList<>();
+        if (this.getQualifiedName() == null || this.getQualifiedName().length() == 0) {
+            missing.add("qualifiedName");
+        }
+        if (this.getName() == null || this.getName().length() == 0) {
+            missing.add("name");
+        }
+        if (!missing.isEmpty()) {
+            throw new InvalidRequestException(
+                    ErrorCode.MISSING_REQUIRED_UPDATE_PARAM, "QlikSpace", String.join(",", missing));
+        }
+        return updater(this.getQualifiedName(), this.getName());
+    }
+
+    /**
+     * Retrieves a QlikSpace by its GUID, complete with all of its relationships.
+     *
+     * @param guid of the QlikSpace to retrieve
+     * @return the requested full QlikSpace, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikSpace does not exist or the provided GUID is not a QlikSpace
+     */
+    public static QlikSpace retrieveByGuid(String guid) throws AtlanException {
+        Asset asset = Asset.retrieveFull(guid);
+        if (asset == null) {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, guid);
+        } else if (asset instanceof QlikSpace) {
+            return (QlikSpace) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_TYPE_REQUESTED, guid, "QlikSpace");
+        }
+    }
+
+    /**
+     * Retrieves a QlikSpace by its qualifiedName, complete with all of its relationships.
+     *
+     * @param qualifiedName of the QlikSpace to retrieve
+     * @return the requested full QlikSpace, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the QlikSpace does not exist
+     */
+    public static QlikSpace retrieveByQualifiedName(String qualifiedName) throws AtlanException {
+        Asset asset = Asset.retrieveFull(TYPE_NAME, qualifiedName);
+        if (asset instanceof QlikSpace) {
+            return (QlikSpace) asset;
+        } else {
+            throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_QN, qualifiedName, "QlikSpace");
+        }
+    }
+
+    /**
+     * Restore the archived (soft-deleted) QlikSpace to active.
+     *
+     * @param qualifiedName for the QlikSpace
+     * @return true if the QlikSpace is now active, and false otherwise
+     * @throws AtlanException on any API problems
+     */
+    public static boolean restore(String qualifiedName) throws AtlanException {
+        return Asset.restore(TYPE_NAME, qualifiedName);
+    }
+
+    /**
+     * Remove the system description from a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param name of the QlikSpace
+     * @return the updated QlikSpace, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace removeDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikSpace) Asset.removeDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the user's description from a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param name of the QlikSpace
+     * @return the updated QlikSpace, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace removeUserDescription(String qualifiedName, String name) throws AtlanException {
+        return (QlikSpace) Asset.removeUserDescription(updater(qualifiedName, name));
+    }
+
+    /**
+     * Remove the owners from a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param name of the QlikSpace
+     * @return the updated QlikSpace, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace removeOwners(String qualifiedName, String name) throws AtlanException {
+        return (QlikSpace) Asset.removeOwners(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the certificate on a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param certificate to use
+     * @param message (optional) message, or null if no message
+     * @return the updated QlikSpace, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace updateCertificate(String qualifiedName, AtlanCertificateStatus certificate, String message)
+            throws AtlanException {
+        return (QlikSpace) Asset.updateCertificate(builder(), TYPE_NAME, qualifiedName, certificate, message);
+    }
+
+    /**
+     * Remove the certificate from a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param name of the QlikSpace
+     * @return the updated QlikSpace, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace removeCertificate(String qualifiedName, String name) throws AtlanException {
+        return (QlikSpace) Asset.removeCertificate(updater(qualifiedName, name));
+    }
+
+    /**
+     * Update the announcement on a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param type type of announcement to set
+     * @param title (optional) title of the announcement to set (or null for no title)
+     * @param message (optional) message of the announcement to set (or null for no message)
+     * @return the result of the update, or null if the update failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace updateAnnouncement(
+            String qualifiedName, AtlanAnnouncementType type, String title, String message) throws AtlanException {
+        return (QlikSpace) Asset.updateAnnouncement(builder(), TYPE_NAME, qualifiedName, type, title, message);
+    }
+
+    /**
+     * Remove the announcement from a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param name of the QlikSpace
+     * @return the updated QlikSpace, or null if the removal failed
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace removeAnnouncement(String qualifiedName, String name) throws AtlanException {
+        return (QlikSpace) Asset.removeAnnouncement(updater(qualifiedName, name));
+    }
+
+    /**
+     * Add classifications to a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param classificationNames human-readable names of the classifications to add
+     * @throws AtlanException on any API problems, or if any of the classifications already exist on the QlikSpace
+     */
+    public static void addClassifications(String qualifiedName, List<String> classificationNames)
+            throws AtlanException {
+        Asset.addClassifications(TYPE_NAME, qualifiedName, classificationNames);
+    }
+
+    /**
+     * Remove a classification from a QlikSpace.
+     *
+     * @param qualifiedName of the QlikSpace
+     * @param classificationName human-readable name of the classification to remove
+     * @throws AtlanException on any API problems, or if the classification does not exist on the QlikSpace
+     */
+    public static void removeClassification(String qualifiedName, String classificationName) throws AtlanException {
+        Asset.removeClassification(TYPE_NAME, qualifiedName, classificationName);
+    }
+
+    /**
+     * Replace the terms linked to the QlikSpace.
+     *
+     * @param qualifiedName for the QlikSpace
+     * @param name human-readable name of the QlikSpace
+     * @param terms the list of terms to replace on the QlikSpace, or null to remove all terms from the QlikSpace
+     * @return the QlikSpace that was updated (note that it will NOT contain details of the replaced terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace replaceTerms(String qualifiedName, String name, List<GlossaryTerm> terms)
+            throws AtlanException {
+        return (QlikSpace) Asset.replaceTerms(updater(qualifiedName, name), terms);
+    }
+
+    /**
+     * Link additional terms to the QlikSpace, without replacing existing terms linked to the QlikSpace.
+     * Note: this operation must make two API calls — one to retrieve the QlikSpace's existing terms,
+     * and a second to append the new terms.
+     *
+     * @param qualifiedName for the QlikSpace
+     * @param terms the list of terms to append to the QlikSpace
+     * @return the QlikSpace that was updated  (note that it will NOT contain details of the appended terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace appendTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikSpace) Asset.appendTerms(TYPE_NAME, qualifiedName, terms);
+    }
+
+    /**
+     * Remove terms from a QlikSpace, without replacing all existing terms linked to the QlikSpace.
+     * Note: this operation must make two API calls — one to retrieve the QlikSpace's existing terms,
+     * and a second to remove the provided terms.
+     *
+     * @param qualifiedName for the QlikSpace
+     * @param terms the list of terms to remove from the QlikSpace, which must be referenced by GUID
+     * @return the QlikSpace that was updated (note that it will NOT contain details of the resulting terms)
+     * @throws AtlanException on any API problems
+     */
+    public static QlikSpace removeTerms(String qualifiedName, List<GlossaryTerm> terms) throws AtlanException {
+        return (QlikSpace) Asset.removeTerms(TYPE_NAME, qualifiedName, terms);
+    }
+}

--- a/src/main/java/com/atlan/model/assets/SQL.java
+++ b/src/main/java/com/atlan/model/assets/SQL.java
@@ -100,4 +100,9 @@ public abstract class SQL extends Catalog {
     @Attribute
     @Singular
     SortedSet<DbtSource> dbtSources;
+
+    /** TBC */
+    @Attribute
+    @Singular
+    SortedSet<DbtSource> sqlDBTSources;
 }

--- a/src/main/java/com/atlan/model/assets/Table.java
+++ b/src/main/java/com/atlan/model/assets/Table.java
@@ -98,11 +98,6 @@ public class Table extends SQL {
     @Singular
     SortedSet<TablePartition> partitions;
 
-    /** Schema in which this table exists. */
-    @Attribute
-    @JsonProperty("atlanSchema")
-    Schema schema;
-
     /** Columns that exist within this table. */
     @Attribute
     @Singular
@@ -112,6 +107,11 @@ public class Table extends SQL {
     @Attribute
     @Singular
     SortedSet<AtlanQuery> queries;
+
+    /** Schema in which this table exists. */
+    @Attribute
+    @JsonProperty("atlanSchema")
+    Schema schema;
 
     /**
      * Reference to a Table by GUID.

--- a/src/main/java/com/atlan/model/enums/BooleanFields.java
+++ b/src/main/java/com/atlan/model/enums/BooleanFields.java
@@ -123,6 +123,16 @@ public enum BooleanFields implements AtlanSearchableField {
     PRESET_WORKSPACE_IS_IN_MAINTENANCE_MODE("presetWorkspaceIsInMaintenanceMode"),
     /** Whether public collections are allowed in the workspace (true) or not (false). */
     PRESET_WORKSPACE_PUBLIC_DASHBOARDS_ALLOWED("presetWorkspacePublicDashboardsAllowed"),
+    /** TBC */
+    QLIK_HAS_SECTION_ACCESS("qlikHasSectionAccess"),
+    /** TBC */
+    QLIK_IS_DIRECT_QUERY_MODE("qlikIsDirectQueryMode"),
+    /** TBC */
+    QLIK_IS_ENCRYPTED("qlikIsEncrypted"),
+    /** TBC */
+    QLIK_IS_PUBLISHED("qlikIsPublished"),
+    /** TBC */
+    QLIK_SHEET_IS_APPROVED("qlikSheetIsApproved"),
     /** Whether versioning is enabled for the bucket. */
     S3BUCKET_VERSIONING_ENABLED("s3BucketVersioningEnabled"),
     /** TBC */

--- a/src/main/java/com/atlan/model/enums/KeywordFields.java
+++ b/src/main/java/com/atlan/model/enums/KeywordFields.java
@@ -579,6 +579,36 @@ public enum KeywordFields implements AtlanSearchableField {
     PROJECT_QUALIFIED_NAME("projectQualifiedName"),
     /** All propagated classifications that exist on an asset, searchable by the internal hashed-string ID of the classification. */
     PROPAGATED_TRAIT_NAMES("__propagatedTraitNames"),
+    /** TBC */
+    QLIK_APP_ID("qlikAppId"),
+    /** TBC */
+    QLIK_APP_QUALIFIED_NAME("qlikAppQualifiedName"),
+    /** TBC */
+    QLIK_CHART_ORIENTATION("qlikChartOrientation"),
+    /** TBC */
+    QLIK_CHART_TYPE("qlikChartType"),
+    /** TBC */
+    QLIK_DATASET_SUBTYPE("qlikDatasetSubtype"),
+    /** TBC */
+    QLIK_DATASET_TECHNICAL_NAME("qlikDatasetTechnicalName.keyword"),
+    /** TBC */
+    QLIK_DATASET_TYPE("qlikDatasetType"),
+    /** TBC */
+    QLIK_DATASET_URI("qlikDatasetUri"),
+    /** TBC */
+    QLIK_ID("qlikId"),
+    /** TBC */
+    QLIK_ORIGIN_APP_ID("qlikOriginAppId"),
+    /** TBC */
+    QLIK_OWNER_ID("qlikOwnerId"),
+    /** TBC */
+    QLIK_QRI("qlikQRI"),
+    /** TBC */
+    QLIK_SPACE_ID("qlikSpaceId"),
+    /** TBC */
+    QLIK_SPACE_QUALIFIED_NAME("qlikSpaceQualifiedName"),
+    /** TBC */
+    QLIK_SPACE_TYPE("qlikSpaceType"),
     /** Unique name for this asset. This is typically a concatenation of the asset's name onto its parent's qualifiedName. */
     QUALIFIED_NAME("qualifiedName"),
     /** TBC */

--- a/src/main/java/com/atlan/model/enums/NumericFields.java
+++ b/src/main/java/com/atlan/model/enums/NumericFields.java
@@ -198,6 +198,8 @@ public enum NumericFields implements AtlanSearchableField {
     /** ID of the Preset asset's workspace. */
     PRESET_WORKSPACE_ID("presetWorkspaceId"),
     /** TBC */
+    QLIK_APP_STATIC_BYTE_SIZE("qlikAppStaticByteSize"),
+    /** TBC */
     QUERY_COUNT("queryCount"),
     /** Time (epoch) at which the query count was last updated, in milliseconds. */
     QUERY_COUNT_UPDATED_AT("queryCountUpdatedAt"),

--- a/src/main/java/com/atlan/model/enums/TextFields.java
+++ b/src/main/java/com/atlan/model/enums/TextFields.java
@@ -203,6 +203,20 @@ public enum TextFields implements AtlanSearchableField {
     PRESET_WORKSPACE_QUALIFIED_NAME("presetWorkspaceQualifiedName.text"),
     /** Region of the workspace. */
     PRESET_WORKSPACE_REGION("presetWorkspaceRegion.text"),
+    /** TBC */
+    QLIK_APP_QUALIFIED_NAME("qlikAppQualifiedName.text"),
+    /** TBC */
+    QLIK_CHART_FOOTNOTE("qlikChartFootnote"),
+    /** TBC */
+    QLIK_CHART_SUBTITLE("qlikChartSubtitle"),
+    /** TBC */
+    QLIK_DATASET_TECHNICAL_NAME("qlikDatasetTechnicalName"),
+    /** TBC */
+    QLIK_DATASET_URI("qlikDatasetUri.text"),
+    /** TBC */
+    QLIK_QRI("qlikQRI.text"),
+    /** TBC */
+    QLIK_SPACE_QUALIFIED_NAME("qlikSpaceQualifiedName.text"),
     /** Unique name for this asset. This is typically a concatenation of the asset's name onto its parent's qualifiedName. */
     QUALIFIED_NAME("qualifiedName.text"),
     /** Name of the bucket in which the object exists. */

--- a/src/main/java/com/atlan/model/typedefs/AttributeDef.java
+++ b/src/main/java/com/atlan/model/typedefs/AttributeDef.java
@@ -7,6 +7,7 @@ import com.atlan.exception.AtlanException;
 import com.atlan.model.core.AtlanObject;
 import com.atlan.model.enums.AtlanCustomAttributeCardinality;
 import com.atlan.model.enums.AtlanCustomAttributePrimitiveType;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.List;
 import java.util.Map;
 import lombok.*;
@@ -37,8 +38,7 @@ public class AttributeDef extends AtlanObject {
     public static AttributeDef of(
             String displayName, AtlanCustomAttributePrimitiveType type, String optionsName, boolean multiValued)
             throws AtlanException {
-        AttributeDefBuilder<?, ?> builder =
-                AttributeDef.builder().name(displayName).displayName(displayName);
+        AttributeDefBuilder<?, ?> builder = AttributeDef.builder().displayName(displayName);
         String baseType;
         boolean addEnumValues = false;
         switch (type) {
@@ -71,13 +71,17 @@ public class AttributeDef extends AtlanObject {
     }
 
     /** Internal hashed-string name for the attribute. */
-    String name;
+    @Builder.Default
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    String name = "";
 
     /** Human-readable name of the attribute. */
     String displayName;
 
     /** Explanation of the attribute. */
-    String description;
+    @Builder.Default
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    String description = "";
 
     /**
      * Type of the attribute.

--- a/src/main/java/com/atlan/model/typedefs/AttributeDefOptions.java
+++ b/src/main/java/com/atlan/model/typedefs/AttributeDefOptions.java
@@ -108,7 +108,13 @@ public class AttributeDefOptions extends AtlanObject {
             GCSBucket.TYPE_NAME,
             GCSObject.TYPE_NAME,
             APISpec.TYPE_NAME,
-            APIPath.TYPE_NAME);
+            APIPath.TYPE_NAME,
+            SigmaPage.TYPE_NAME,
+            SigmaDataset.TYPE_NAME,
+            SigmaDataElement.TYPE_NAME,
+            SigmaWorkbook.TYPE_NAME,
+            SigmaDataElementField.TYPE_NAME,
+            SigmaDatasetColumn.TYPE_NAME);
 
     /**
      * Instantiate a new set of attribute options from the provided parameters.
@@ -177,7 +183,8 @@ public class AttributeDefOptions extends AtlanObject {
     AtlanCustomAttributePrimitiveType primitiveType;
 
     /** Whether the attribute is an enumeration (true) or not (false). */
-    Boolean isEnum;
+    @Builder.Default
+    Boolean isEnum = false;
 
     /** Name of the enumeration (options), when the attribute is an enumeration. */
     String enumType;
@@ -186,8 +193,7 @@ public class AttributeDefOptions extends AtlanObject {
     String customType;
 
     /** Whether the attribute has been deleted (true) or is still active (false). */
-    @Builder.Default
-    Boolean isArchived = false;
+    Boolean isArchived;
 
     /** When the attribute was deleted. */
     Long archivedAt;

--- a/src/main/java/com/atlan/serde/AssetDeserializer.java
+++ b/src/main/java/com/atlan/serde/AssetDeserializer.java
@@ -276,6 +276,21 @@ public class AssetDeserializer extends StdDeserializer<Asset> {
                 case Procedure.TYPE_NAME:
                     builder = Procedure.builder();
                     break;
+                case QlikApp.TYPE_NAME:
+                    builder = QlikApp.builder();
+                    break;
+                case QlikChart.TYPE_NAME:
+                    builder = QlikChart.builder();
+                    break;
+                case QlikDataset.TYPE_NAME:
+                    builder = QlikDataset.builder();
+                    break;
+                case QlikSheet.TYPE_NAME:
+                    builder = QlikSheet.builder();
+                    break;
+                case QlikSpace.TYPE_NAME:
+                    builder = QlikSpace.builder();
+                    break;
                 case Readme.TYPE_NAME:
                     builder = Readme.builder();
                     break;

--- a/src/test/java/com/atlan/model/assets/DbtSourceTest.java
+++ b/src/test/java/com/atlan/model/assets/DbtSourceTest.java
@@ -132,6 +132,7 @@ public class DbtSourceTest {
             .dbtSemanticLayerProxyUrl("dbtSemanticLayerProxyUrl")
             .dbtState("dbtState")
             .dbtFreshnessCriteria("dbtFreshnessCriteria")
+            .primarySqlAsset(Table.refByGuid("3a7108c3-1fa1-4234-b6a4-1d3ee55d5dac"))
             .sqlAsset(Table.refByGuid("3a7108c3-1fa1-4234-b6a4-1d3ee55d5dac"))
             .build();
     private static DbtSource frodo;

--- a/src/test/java/com/atlan/model/assets/QlikAppTest.java
+++ b/src/test/java/com/atlan/model/assets/QlikAppTest.java
@@ -1,0 +1,177 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import static org.testng.Assert.*;
+
+import com.atlan.model.enums.*;
+import com.atlan.serde.Serde;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.*;
+import org.testng.annotations.Test;
+
+public class QlikAppTest {
+
+    private static final QlikApp full = QlikApp.builder()
+            .guid("guid")
+            .displayText("displayText")
+            .status(AtlanStatus.ACTIVE)
+            .createdBy("createdBy")
+            .updatedBy("updatedBy")
+            .createTime(123456789L)
+            .updateTime(123456789L)
+            .isIncomplete(false)
+            .qualifiedName("qualifiedName")
+            .name("name")
+            .displayName("displayName")
+            .description("description")
+            .userDescription("userDescription")
+            .tenantId("tenantId")
+            .certificateStatus(AtlanCertificateStatus.VERIFIED)
+            .certificateStatusMessage("certificateStatusMessage")
+            .certificateUpdatedBy("certificateUpdatedBy")
+            .certificateUpdatedAt(123456789L)
+            .announcementTitle("announcementTitle")
+            .announcementMessage("announcementMessage")
+            .announcementUpdatedAt(123456789L)
+            .announcementUpdatedBy("announcementUpdatedBy")
+            .announcementType(AtlanAnnouncementType.INFORMATION)
+            .ownerUser("ownerUser")
+            .ownerGroup("ownerGroup")
+            .adminUser("adminUser")
+            .adminGroup("adminGroup")
+            .adminRole("adminRole")
+            .viewerUser("viewerUser")
+            .viewerGroup("viewerGroup")
+            .connectorType(AtlanConnectorType.PRESTO)
+            .connectionName("connectionName")
+            .connectionQualifiedName("connectionQualifiedName")
+            .hasLineage(false)
+            .isDiscoverable(true)
+            .isEditable(true)
+            .viewScore(123456.0)
+            .popularityScore(123456.0)
+            .sourceOwners("sourceOwners")
+            .sourceURL("sourceURL")
+            .sourceEmbedURL("sourceEmbedURL")
+            .lastSyncWorkflowName("lastSyncWorkflowName")
+            .lastSyncRunAt(123456789L)
+            .lastSyncRun("lastSyncRun")
+            .sourceCreatedBy("sourceCreatedBy")
+            .sourceCreatedAt(123456789L)
+            .sourceUpdatedAt(123456789L)
+            .sourceUpdatedBy("sourceUpdatedBy")
+            .dbtQualifiedName("dbtQualifiedName")
+            .assetDbtAlias("assetDbtAlias")
+            .assetDbtMeta("assetDbtMeta")
+            .assetDbtUniqueId("assetDbtUniqueId")
+            .assetDbtAccountName("assetDbtAccountName")
+            .assetDbtProjectName("assetDbtProjectName")
+            .assetDbtPackageName("assetDbtPackageName")
+            .assetDbtJobName("assetDbtJobName")
+            .assetDbtJobSchedule("assetDbtJobSchedule")
+            .assetDbtJobStatus("assetDbtJobStatus")
+            .assetDbtJobScheduleCronHumanized("assetDbtJobScheduleCronHumanized")
+            .assetDbtJobLastRun(123456789L)
+            .assetDbtJobLastRunUrl("assetDbtJobLastRunUrl")
+            .assetDbtJobLastRunCreatedAt(123456789L)
+            .assetDbtJobLastRunUpdatedAt(123456789L)
+            .assetDbtJobLastRunDequedAt(123456789L)
+            .assetDbtJobLastRunStartedAt(123456789L)
+            .assetDbtJobLastRunTotalDuration("assetDbtJobLastRunTotalDuration")
+            .assetDbtJobLastRunTotalDurationHumanized("assetDbtJobLastRunTotalDurationHumanized")
+            .assetDbtJobLastRunQueuedDuration("assetDbtJobLastRunQueuedDuration")
+            .assetDbtJobLastRunQueuedDurationHumanized("assetDbtJobLastRunQueuedDurationHumanized")
+            .assetDbtJobLastRunRunDuration("assetDbtJobLastRunRunDuration")
+            .assetDbtJobLastRunRunDurationHumanized("assetDbtJobLastRunRunDurationHumanized")
+            .assetDbtJobLastRunGitBranch("assetDbtJobLastRunGitBranch")
+            .assetDbtJobLastRunGitSha("assetDbtJobLastRunGitSha")
+            .assetDbtJobLastRunStatusMessage("assetDbtJobLastRunStatusMessage")
+            .assetDbtJobLastRunOwnerThreadId("assetDbtJobLastRunOwnerThreadId")
+            .assetDbtJobLastRunExecutedByThreadId("assetDbtJobLastRunExecutedByThreadId")
+            .assetDbtJobLastRunArtifactsSaved(true)
+            .assetDbtJobLastRunArtifactS3Path("assetDbtJobLastRunArtifactS3Path")
+            .assetDbtJobLastRunHasDocsGenerated(false)
+            .assetDbtJobLastRunHasSourcesGenerated(true)
+            .assetDbtJobLastRunNotificationsSent(false)
+            .assetDbtJobNextRun(123456789L)
+            .assetDbtJobNextRunHumanized("assetDbtJobNextRunHumanized")
+            .assetDbtEnvironmentName("assetDbtEnvironmentName")
+            .assetDbtEnvironmentDbtVersion("assetDbtEnvironmentDbtVersion")
+            .assetDbtTag("assetDbtTag1")
+            .assetDbtTag("assetDbtTag2")
+            .assetDbtSemanticLayerProxyUrl("assetDbtSemanticLayerProxyUrl")
+            .link(Link.refByGuid("linkGuid1"))
+            .link(Link.refByGuid("linkGuid2"))
+            .readme(Readme.refByGuid("readmeGuid"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid1"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid2"))
+            .inputToProcesses(Set.of(
+                    LineageProcess.refByGuid("cf50601c-de99-47c8-ac2b-86cd6fa60fae"),
+                    LineageProcess.refByGuid("66799fbc-8fd2-42b1-b631-818c42300a02")))
+            .outputFromProcesses(Set.of(
+                    LineageProcess.refByGuid("53961f6d-e3bd-43d7-98f6-39662a8a0be6"),
+                    LineageProcess.refByGuid("9e76029a-aec0-4ab6-a1d8-3eb7d095383c")))
+            .qlikId("qlikId")
+            .qlikQRI("qlikQRI")
+            .qlikSpaceId("qlikSpaceId")
+            .qlikSpaceQualifiedName("qlikSpaceQualifiedName")
+            .qlikAppId("qlikAppId")
+            .qlikAppQualifiedName("qlikAppQualifiedName")
+            .qlikOwnerId("qlikOwnerId")
+            .qlikIsPublished(false)
+            .qlikHasSectionAccess(false)
+            .qlikOriginAppId("qlikOriginAppId")
+            .qlikIsEncrypted(true)
+            .qlikIsDirectQueryMode(true)
+            .qlikAppStaticByteSize(-2427812656943482981L)
+            .qlikSpace(QlikSpace.refByGuid("c49a241b-d568-4d36-b1ad-c58aa48bf24e"))
+            .qlikSheets(Set.of(
+                    QlikSheet.refByGuid("01d530b6-0407-4a6b-a056-30a7570db472"),
+                    QlikSheet.refByGuid("20ee19fb-744e-47d2-b586-b45725c63b42")))
+            .build();
+    private static QlikApp frodo;
+    private static String serialized;
+
+    @Test(groups = {"builderEquivalency"})
+    void builderEquivalency() {
+        assertEquals(full.toBuilder().build(), full);
+    }
+
+    @Test(
+            groups = {"serialize"},
+            dependsOnGroups = {"builderEquivalency"})
+    void serialization() {
+        assertNotNull(full);
+        serialized = full.toJson();
+        assertNotNull(serialized);
+    }
+
+    @Test(
+            groups = {"deserialize"},
+            dependsOnGroups = {"serialize"})
+    void deserialization() throws JsonProcessingException {
+        assertNotNull(serialized);
+        frodo = Serde.mapper.readValue(serialized, QlikApp.class);
+        assertNotNull(frodo);
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void serializedEquivalency() {
+        assertNotNull(serialized);
+        assertNotNull(frodo);
+        String backAgain = frodo.toJson();
+        assertEquals(backAgain, serialized, "Serialization is not equivalent after serde loop,");
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void deserializedEquivalency() {
+        assertNotNull(full);
+        assertNotNull(frodo);
+        assertEquals(frodo, full, "Deserialization is not equivalent after serde loop,");
+    }
+}

--- a/src/test/java/com/atlan/model/assets/QlikChartTest.java
+++ b/src/test/java/com/atlan/model/assets/QlikChartTest.java
@@ -1,0 +1,173 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import static org.testng.Assert.*;
+
+import com.atlan.model.enums.*;
+import com.atlan.serde.Serde;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.*;
+import org.testng.annotations.Test;
+
+public class QlikChartTest {
+
+    private static final QlikChart full = QlikChart.builder()
+            .guid("guid")
+            .displayText("displayText")
+            .status(AtlanStatus.ACTIVE)
+            .createdBy("createdBy")
+            .updatedBy("updatedBy")
+            .createTime(123456789L)
+            .updateTime(123456789L)
+            .isIncomplete(false)
+            .qualifiedName("qualifiedName")
+            .name("name")
+            .displayName("displayName")
+            .description("description")
+            .userDescription("userDescription")
+            .tenantId("tenantId")
+            .certificateStatus(AtlanCertificateStatus.VERIFIED)
+            .certificateStatusMessage("certificateStatusMessage")
+            .certificateUpdatedBy("certificateUpdatedBy")
+            .certificateUpdatedAt(123456789L)
+            .announcementTitle("announcementTitle")
+            .announcementMessage("announcementMessage")
+            .announcementUpdatedAt(123456789L)
+            .announcementUpdatedBy("announcementUpdatedBy")
+            .announcementType(AtlanAnnouncementType.INFORMATION)
+            .ownerUser("ownerUser")
+            .ownerGroup("ownerGroup")
+            .adminUser("adminUser")
+            .adminGroup("adminGroup")
+            .adminRole("adminRole")
+            .viewerUser("viewerUser")
+            .viewerGroup("viewerGroup")
+            .connectorType(AtlanConnectorType.PRESTO)
+            .connectionName("connectionName")
+            .connectionQualifiedName("connectionQualifiedName")
+            .hasLineage(false)
+            .isDiscoverable(true)
+            .isEditable(true)
+            .viewScore(123456.0)
+            .popularityScore(123456.0)
+            .sourceOwners("sourceOwners")
+            .sourceURL("sourceURL")
+            .sourceEmbedURL("sourceEmbedURL")
+            .lastSyncWorkflowName("lastSyncWorkflowName")
+            .lastSyncRunAt(123456789L)
+            .lastSyncRun("lastSyncRun")
+            .sourceCreatedBy("sourceCreatedBy")
+            .sourceCreatedAt(123456789L)
+            .sourceUpdatedAt(123456789L)
+            .sourceUpdatedBy("sourceUpdatedBy")
+            .dbtQualifiedName("dbtQualifiedName")
+            .assetDbtAlias("assetDbtAlias")
+            .assetDbtMeta("assetDbtMeta")
+            .assetDbtUniqueId("assetDbtUniqueId")
+            .assetDbtAccountName("assetDbtAccountName")
+            .assetDbtProjectName("assetDbtProjectName")
+            .assetDbtPackageName("assetDbtPackageName")
+            .assetDbtJobName("assetDbtJobName")
+            .assetDbtJobSchedule("assetDbtJobSchedule")
+            .assetDbtJobStatus("assetDbtJobStatus")
+            .assetDbtJobScheduleCronHumanized("assetDbtJobScheduleCronHumanized")
+            .assetDbtJobLastRun(123456789L)
+            .assetDbtJobLastRunUrl("assetDbtJobLastRunUrl")
+            .assetDbtJobLastRunCreatedAt(123456789L)
+            .assetDbtJobLastRunUpdatedAt(123456789L)
+            .assetDbtJobLastRunDequedAt(123456789L)
+            .assetDbtJobLastRunStartedAt(123456789L)
+            .assetDbtJobLastRunTotalDuration("assetDbtJobLastRunTotalDuration")
+            .assetDbtJobLastRunTotalDurationHumanized("assetDbtJobLastRunTotalDurationHumanized")
+            .assetDbtJobLastRunQueuedDuration("assetDbtJobLastRunQueuedDuration")
+            .assetDbtJobLastRunQueuedDurationHumanized("assetDbtJobLastRunQueuedDurationHumanized")
+            .assetDbtJobLastRunRunDuration("assetDbtJobLastRunRunDuration")
+            .assetDbtJobLastRunRunDurationHumanized("assetDbtJobLastRunRunDurationHumanized")
+            .assetDbtJobLastRunGitBranch("assetDbtJobLastRunGitBranch")
+            .assetDbtJobLastRunGitSha("assetDbtJobLastRunGitSha")
+            .assetDbtJobLastRunStatusMessage("assetDbtJobLastRunStatusMessage")
+            .assetDbtJobLastRunOwnerThreadId("assetDbtJobLastRunOwnerThreadId")
+            .assetDbtJobLastRunExecutedByThreadId("assetDbtJobLastRunExecutedByThreadId")
+            .assetDbtJobLastRunArtifactsSaved(true)
+            .assetDbtJobLastRunArtifactS3Path("assetDbtJobLastRunArtifactS3Path")
+            .assetDbtJobLastRunHasDocsGenerated(false)
+            .assetDbtJobLastRunHasSourcesGenerated(true)
+            .assetDbtJobLastRunNotificationsSent(false)
+            .assetDbtJobNextRun(123456789L)
+            .assetDbtJobNextRunHumanized("assetDbtJobNextRunHumanized")
+            .assetDbtEnvironmentName("assetDbtEnvironmentName")
+            .assetDbtEnvironmentDbtVersion("assetDbtEnvironmentDbtVersion")
+            .assetDbtTag("assetDbtTag1")
+            .assetDbtTag("assetDbtTag2")
+            .assetDbtSemanticLayerProxyUrl("assetDbtSemanticLayerProxyUrl")
+            .link(Link.refByGuid("linkGuid1"))
+            .link(Link.refByGuid("linkGuid2"))
+            .readme(Readme.refByGuid("readmeGuid"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid1"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid2"))
+            .inputToProcesses(Set.of(
+                    LineageProcess.refByGuid("2f55617d-ba98-46c0-920a-59bb89081ad8"),
+                    LineageProcess.refByGuid("c3b576aa-f97a-4612-a152-422c4b8bcd6d")))
+            .outputFromProcesses(Set.of(
+                    LineageProcess.refByGuid("fa687f15-a8f6-4b4f-a903-38afeb2119ca"),
+                    LineageProcess.refByGuid("a6a5da36-74e5-43af-a1d6-fbfa1c75b2e1")))
+            .qlikId("qlikId")
+            .qlikQRI("qlikQRI")
+            .qlikSpaceId("qlikSpaceId")
+            .qlikSpaceQualifiedName("qlikSpaceQualifiedName")
+            .qlikAppId("qlikAppId")
+            .qlikAppQualifiedName("qlikAppQualifiedName")
+            .qlikOwnerId("qlikOwnerId")
+            .qlikIsPublished(false)
+            .qlikChartSubtitle("qlikChartSubtitle")
+            .qlikChartFootnote("qlikChartFootnote")
+            .qlikChartOrientation("qlikChartOrientation")
+            .qlikChartType("qlikChartType")
+            .qlikSheet(QlikSheet.refByGuid("f849a9c1-cf32-48a2-ad93-37ccabba1ab9"))
+            .build();
+    private static QlikChart frodo;
+    private static String serialized;
+
+    @Test(groups = {"builderEquivalency"})
+    void builderEquivalency() {
+        assertEquals(full.toBuilder().build(), full);
+    }
+
+    @Test(
+            groups = {"serialize"},
+            dependsOnGroups = {"builderEquivalency"})
+    void serialization() {
+        assertNotNull(full);
+        serialized = full.toJson();
+        assertNotNull(serialized);
+    }
+
+    @Test(
+            groups = {"deserialize"},
+            dependsOnGroups = {"serialize"})
+    void deserialization() throws JsonProcessingException {
+        assertNotNull(serialized);
+        frodo = Serde.mapper.readValue(serialized, QlikChart.class);
+        assertNotNull(frodo);
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void serializedEquivalency() {
+        assertNotNull(serialized);
+        assertNotNull(frodo);
+        String backAgain = frodo.toJson();
+        assertEquals(backAgain, serialized, "Serialization is not equivalent after serde loop,");
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void deserializedEquivalency() {
+        assertNotNull(full);
+        assertNotNull(frodo);
+        assertEquals(frodo, full, "Deserialization is not equivalent after serde loop,");
+    }
+}

--- a/src/test/java/com/atlan/model/assets/QlikDatasetTest.java
+++ b/src/test/java/com/atlan/model/assets/QlikDatasetTest.java
@@ -1,0 +1,173 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import static org.testng.Assert.*;
+
+import com.atlan.model.enums.*;
+import com.atlan.serde.Serde;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.*;
+import org.testng.annotations.Test;
+
+public class QlikDatasetTest {
+
+    private static final QlikDataset full = QlikDataset.builder()
+            .guid("guid")
+            .displayText("displayText")
+            .status(AtlanStatus.ACTIVE)
+            .createdBy("createdBy")
+            .updatedBy("updatedBy")
+            .createTime(123456789L)
+            .updateTime(123456789L)
+            .isIncomplete(false)
+            .qualifiedName("qualifiedName")
+            .name("name")
+            .displayName("displayName")
+            .description("description")
+            .userDescription("userDescription")
+            .tenantId("tenantId")
+            .certificateStatus(AtlanCertificateStatus.VERIFIED)
+            .certificateStatusMessage("certificateStatusMessage")
+            .certificateUpdatedBy("certificateUpdatedBy")
+            .certificateUpdatedAt(123456789L)
+            .announcementTitle("announcementTitle")
+            .announcementMessage("announcementMessage")
+            .announcementUpdatedAt(123456789L)
+            .announcementUpdatedBy("announcementUpdatedBy")
+            .announcementType(AtlanAnnouncementType.INFORMATION)
+            .ownerUser("ownerUser")
+            .ownerGroup("ownerGroup")
+            .adminUser("adminUser")
+            .adminGroup("adminGroup")
+            .adminRole("adminRole")
+            .viewerUser("viewerUser")
+            .viewerGroup("viewerGroup")
+            .connectorType(AtlanConnectorType.PRESTO)
+            .connectionName("connectionName")
+            .connectionQualifiedName("connectionQualifiedName")
+            .hasLineage(false)
+            .isDiscoverable(true)
+            .isEditable(true)
+            .viewScore(123456.0)
+            .popularityScore(123456.0)
+            .sourceOwners("sourceOwners")
+            .sourceURL("sourceURL")
+            .sourceEmbedURL("sourceEmbedURL")
+            .lastSyncWorkflowName("lastSyncWorkflowName")
+            .lastSyncRunAt(123456789L)
+            .lastSyncRun("lastSyncRun")
+            .sourceCreatedBy("sourceCreatedBy")
+            .sourceCreatedAt(123456789L)
+            .sourceUpdatedAt(123456789L)
+            .sourceUpdatedBy("sourceUpdatedBy")
+            .dbtQualifiedName("dbtQualifiedName")
+            .assetDbtAlias("assetDbtAlias")
+            .assetDbtMeta("assetDbtMeta")
+            .assetDbtUniqueId("assetDbtUniqueId")
+            .assetDbtAccountName("assetDbtAccountName")
+            .assetDbtProjectName("assetDbtProjectName")
+            .assetDbtPackageName("assetDbtPackageName")
+            .assetDbtJobName("assetDbtJobName")
+            .assetDbtJobSchedule("assetDbtJobSchedule")
+            .assetDbtJobStatus("assetDbtJobStatus")
+            .assetDbtJobScheduleCronHumanized("assetDbtJobScheduleCronHumanized")
+            .assetDbtJobLastRun(123456789L)
+            .assetDbtJobLastRunUrl("assetDbtJobLastRunUrl")
+            .assetDbtJobLastRunCreatedAt(123456789L)
+            .assetDbtJobLastRunUpdatedAt(123456789L)
+            .assetDbtJobLastRunDequedAt(123456789L)
+            .assetDbtJobLastRunStartedAt(123456789L)
+            .assetDbtJobLastRunTotalDuration("assetDbtJobLastRunTotalDuration")
+            .assetDbtJobLastRunTotalDurationHumanized("assetDbtJobLastRunTotalDurationHumanized")
+            .assetDbtJobLastRunQueuedDuration("assetDbtJobLastRunQueuedDuration")
+            .assetDbtJobLastRunQueuedDurationHumanized("assetDbtJobLastRunQueuedDurationHumanized")
+            .assetDbtJobLastRunRunDuration("assetDbtJobLastRunRunDuration")
+            .assetDbtJobLastRunRunDurationHumanized("assetDbtJobLastRunRunDurationHumanized")
+            .assetDbtJobLastRunGitBranch("assetDbtJobLastRunGitBranch")
+            .assetDbtJobLastRunGitSha("assetDbtJobLastRunGitSha")
+            .assetDbtJobLastRunStatusMessage("assetDbtJobLastRunStatusMessage")
+            .assetDbtJobLastRunOwnerThreadId("assetDbtJobLastRunOwnerThreadId")
+            .assetDbtJobLastRunExecutedByThreadId("assetDbtJobLastRunExecutedByThreadId")
+            .assetDbtJobLastRunArtifactsSaved(true)
+            .assetDbtJobLastRunArtifactS3Path("assetDbtJobLastRunArtifactS3Path")
+            .assetDbtJobLastRunHasDocsGenerated(false)
+            .assetDbtJobLastRunHasSourcesGenerated(true)
+            .assetDbtJobLastRunNotificationsSent(false)
+            .assetDbtJobNextRun(123456789L)
+            .assetDbtJobNextRunHumanized("assetDbtJobNextRunHumanized")
+            .assetDbtEnvironmentName("assetDbtEnvironmentName")
+            .assetDbtEnvironmentDbtVersion("assetDbtEnvironmentDbtVersion")
+            .assetDbtTag("assetDbtTag1")
+            .assetDbtTag("assetDbtTag2")
+            .assetDbtSemanticLayerProxyUrl("assetDbtSemanticLayerProxyUrl")
+            .link(Link.refByGuid("linkGuid1"))
+            .link(Link.refByGuid("linkGuid2"))
+            .readme(Readme.refByGuid("readmeGuid"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid1"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid2"))
+            .inputToProcesses(Set.of(
+                    LineageProcess.refByGuid("b1e38fb3-c6bc-4b73-aae7-ef7d798d5e91"),
+                    LineageProcess.refByGuid("e8d1c0f6-2117-4278-9016-3e2f0309891d")))
+            .outputFromProcesses(Set.of(
+                    LineageProcess.refByGuid("5bf8d22e-82cd-48f4-9380-95fbff9d1c9a"),
+                    LineageProcess.refByGuid("8f6099c9-9fc0-42ca-8f2c-03158dd1e00d")))
+            .qlikId("qlikId")
+            .qlikQRI("qlikQRI")
+            .qlikSpaceId("qlikSpaceId")
+            .qlikSpaceQualifiedName("qlikSpaceQualifiedName")
+            .qlikAppId("qlikAppId")
+            .qlikAppQualifiedName("qlikAppQualifiedName")
+            .qlikOwnerId("qlikOwnerId")
+            .qlikIsPublished(false)
+            .qlikDatasetTechnicalName("qlikDatasetTechnicalName")
+            .qlikDatasetType("qlikDatasetType")
+            .qlikDatasetUri("qlikDatasetUri")
+            .qlikDatasetSubtype("qlikDatasetSubtype")
+            .qlikSpace(QlikSpace.refByGuid("de41c014-ac8d-4f3f-b3b3-baa693c56afd"))
+            .build();
+    private static QlikDataset frodo;
+    private static String serialized;
+
+    @Test(groups = {"builderEquivalency"})
+    void builderEquivalency() {
+        assertEquals(full.toBuilder().build(), full);
+    }
+
+    @Test(
+            groups = {"serialize"},
+            dependsOnGroups = {"builderEquivalency"})
+    void serialization() {
+        assertNotNull(full);
+        serialized = full.toJson();
+        assertNotNull(serialized);
+    }
+
+    @Test(
+            groups = {"deserialize"},
+            dependsOnGroups = {"serialize"})
+    void deserialization() throws JsonProcessingException {
+        assertNotNull(serialized);
+        frodo = Serde.mapper.readValue(serialized, QlikDataset.class);
+        assertNotNull(frodo);
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void serializedEquivalency() {
+        assertNotNull(serialized);
+        assertNotNull(frodo);
+        String backAgain = frodo.toJson();
+        assertEquals(backAgain, serialized, "Serialization is not equivalent after serde loop,");
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void deserializedEquivalency() {
+        assertNotNull(full);
+        assertNotNull(frodo);
+        assertEquals(frodo, full, "Deserialization is not equivalent after serde loop,");
+    }
+}

--- a/src/test/java/com/atlan/model/assets/QlikSheetTest.java
+++ b/src/test/java/com/atlan/model/assets/QlikSheetTest.java
@@ -1,0 +1,173 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import static org.testng.Assert.*;
+
+import com.atlan.model.enums.*;
+import com.atlan.serde.Serde;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.*;
+import org.testng.annotations.Test;
+
+public class QlikSheetTest {
+
+    private static final QlikSheet full = QlikSheet.builder()
+            .guid("guid")
+            .displayText("displayText")
+            .status(AtlanStatus.ACTIVE)
+            .createdBy("createdBy")
+            .updatedBy("updatedBy")
+            .createTime(123456789L)
+            .updateTime(123456789L)
+            .isIncomplete(false)
+            .qualifiedName("qualifiedName")
+            .name("name")
+            .displayName("displayName")
+            .description("description")
+            .userDescription("userDescription")
+            .tenantId("tenantId")
+            .certificateStatus(AtlanCertificateStatus.VERIFIED)
+            .certificateStatusMessage("certificateStatusMessage")
+            .certificateUpdatedBy("certificateUpdatedBy")
+            .certificateUpdatedAt(123456789L)
+            .announcementTitle("announcementTitle")
+            .announcementMessage("announcementMessage")
+            .announcementUpdatedAt(123456789L)
+            .announcementUpdatedBy("announcementUpdatedBy")
+            .announcementType(AtlanAnnouncementType.INFORMATION)
+            .ownerUser("ownerUser")
+            .ownerGroup("ownerGroup")
+            .adminUser("adminUser")
+            .adminGroup("adminGroup")
+            .adminRole("adminRole")
+            .viewerUser("viewerUser")
+            .viewerGroup("viewerGroup")
+            .connectorType(AtlanConnectorType.PRESTO)
+            .connectionName("connectionName")
+            .connectionQualifiedName("connectionQualifiedName")
+            .hasLineage(false)
+            .isDiscoverable(true)
+            .isEditable(true)
+            .viewScore(123456.0)
+            .popularityScore(123456.0)
+            .sourceOwners("sourceOwners")
+            .sourceURL("sourceURL")
+            .sourceEmbedURL("sourceEmbedURL")
+            .lastSyncWorkflowName("lastSyncWorkflowName")
+            .lastSyncRunAt(123456789L)
+            .lastSyncRun("lastSyncRun")
+            .sourceCreatedBy("sourceCreatedBy")
+            .sourceCreatedAt(123456789L)
+            .sourceUpdatedAt(123456789L)
+            .sourceUpdatedBy("sourceUpdatedBy")
+            .dbtQualifiedName("dbtQualifiedName")
+            .assetDbtAlias("assetDbtAlias")
+            .assetDbtMeta("assetDbtMeta")
+            .assetDbtUniqueId("assetDbtUniqueId")
+            .assetDbtAccountName("assetDbtAccountName")
+            .assetDbtProjectName("assetDbtProjectName")
+            .assetDbtPackageName("assetDbtPackageName")
+            .assetDbtJobName("assetDbtJobName")
+            .assetDbtJobSchedule("assetDbtJobSchedule")
+            .assetDbtJobStatus("assetDbtJobStatus")
+            .assetDbtJobScheduleCronHumanized("assetDbtJobScheduleCronHumanized")
+            .assetDbtJobLastRun(123456789L)
+            .assetDbtJobLastRunUrl("assetDbtJobLastRunUrl")
+            .assetDbtJobLastRunCreatedAt(123456789L)
+            .assetDbtJobLastRunUpdatedAt(123456789L)
+            .assetDbtJobLastRunDequedAt(123456789L)
+            .assetDbtJobLastRunStartedAt(123456789L)
+            .assetDbtJobLastRunTotalDuration("assetDbtJobLastRunTotalDuration")
+            .assetDbtJobLastRunTotalDurationHumanized("assetDbtJobLastRunTotalDurationHumanized")
+            .assetDbtJobLastRunQueuedDuration("assetDbtJobLastRunQueuedDuration")
+            .assetDbtJobLastRunQueuedDurationHumanized("assetDbtJobLastRunQueuedDurationHumanized")
+            .assetDbtJobLastRunRunDuration("assetDbtJobLastRunRunDuration")
+            .assetDbtJobLastRunRunDurationHumanized("assetDbtJobLastRunRunDurationHumanized")
+            .assetDbtJobLastRunGitBranch("assetDbtJobLastRunGitBranch")
+            .assetDbtJobLastRunGitSha("assetDbtJobLastRunGitSha")
+            .assetDbtJobLastRunStatusMessage("assetDbtJobLastRunStatusMessage")
+            .assetDbtJobLastRunOwnerThreadId("assetDbtJobLastRunOwnerThreadId")
+            .assetDbtJobLastRunExecutedByThreadId("assetDbtJobLastRunExecutedByThreadId")
+            .assetDbtJobLastRunArtifactsSaved(true)
+            .assetDbtJobLastRunArtifactS3Path("assetDbtJobLastRunArtifactS3Path")
+            .assetDbtJobLastRunHasDocsGenerated(false)
+            .assetDbtJobLastRunHasSourcesGenerated(true)
+            .assetDbtJobLastRunNotificationsSent(false)
+            .assetDbtJobNextRun(123456789L)
+            .assetDbtJobNextRunHumanized("assetDbtJobNextRunHumanized")
+            .assetDbtEnvironmentName("assetDbtEnvironmentName")
+            .assetDbtEnvironmentDbtVersion("assetDbtEnvironmentDbtVersion")
+            .assetDbtTag("assetDbtTag1")
+            .assetDbtTag("assetDbtTag2")
+            .assetDbtSemanticLayerProxyUrl("assetDbtSemanticLayerProxyUrl")
+            .link(Link.refByGuid("linkGuid1"))
+            .link(Link.refByGuid("linkGuid2"))
+            .readme(Readme.refByGuid("readmeGuid"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid1"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid2"))
+            .inputToProcesses(Set.of(
+                    LineageProcess.refByGuid("9904e79d-544b-4ade-b091-c45fdd8dba0a"),
+                    LineageProcess.refByGuid("ba4e870d-be6c-451e-a4dd-ebb0a6464f05")))
+            .outputFromProcesses(Set.of(
+                    LineageProcess.refByGuid("d069577e-1e5f-4a25-875b-ad787e1df2cf"),
+                    LineageProcess.refByGuid("7fc85dec-e59f-405e-b22c-6d450d299482")))
+            .qlikId("qlikId")
+            .qlikQRI("qlikQRI")
+            .qlikSpaceId("qlikSpaceId")
+            .qlikSpaceQualifiedName("qlikSpaceQualifiedName")
+            .qlikAppId("qlikAppId")
+            .qlikAppQualifiedName("qlikAppQualifiedName")
+            .qlikOwnerId("qlikOwnerId")
+            .qlikIsPublished(true)
+            .qlikSheetIsApproved(false)
+            .qlikApp(QlikApp.refByGuid("abcc35ab-27b1-4ed3-85f5-f7cefd9748c3"))
+            .qlikCharts(Set.of(
+                    QlikChart.refByGuid("38b547d8-d816-46d7-87cd-931a5f8b5aea"),
+                    QlikChart.refByGuid("d6e502e8-b5f5-45fb-850e-94e1c1608502")))
+            .build();
+    private static QlikSheet frodo;
+    private static String serialized;
+
+    @Test(groups = {"builderEquivalency"})
+    void builderEquivalency() {
+        assertEquals(full.toBuilder().build(), full);
+    }
+
+    @Test(
+            groups = {"serialize"},
+            dependsOnGroups = {"builderEquivalency"})
+    void serialization() {
+        assertNotNull(full);
+        serialized = full.toJson();
+        assertNotNull(serialized);
+    }
+
+    @Test(
+            groups = {"deserialize"},
+            dependsOnGroups = {"serialize"})
+    void deserialization() throws JsonProcessingException {
+        assertNotNull(serialized);
+        frodo = Serde.mapper.readValue(serialized, QlikSheet.class);
+        assertNotNull(frodo);
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void serializedEquivalency() {
+        assertNotNull(serialized);
+        assertNotNull(frodo);
+        String backAgain = frodo.toJson();
+        assertEquals(backAgain, serialized, "Serialization is not equivalent after serde loop,");
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void deserializedEquivalency() {
+        assertNotNull(full);
+        assertNotNull(frodo);
+        assertEquals(frodo, full, "Deserialization is not equivalent after serde loop,");
+    }
+}

--- a/src/test/java/com/atlan/model/assets/QlikSpaceTest.java
+++ b/src/test/java/com/atlan/model/assets/QlikSpaceTest.java
@@ -1,0 +1,175 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import static org.testng.Assert.*;
+
+import com.atlan.model.enums.*;
+import com.atlan.serde.Serde;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.*;
+import org.testng.annotations.Test;
+
+public class QlikSpaceTest {
+
+    private static final QlikSpace full = QlikSpace.builder()
+            .guid("guid")
+            .displayText("displayText")
+            .status(AtlanStatus.ACTIVE)
+            .createdBy("createdBy")
+            .updatedBy("updatedBy")
+            .createTime(123456789L)
+            .updateTime(123456789L)
+            .isIncomplete(false)
+            .qualifiedName("qualifiedName")
+            .name("name")
+            .displayName("displayName")
+            .description("description")
+            .userDescription("userDescription")
+            .tenantId("tenantId")
+            .certificateStatus(AtlanCertificateStatus.VERIFIED)
+            .certificateStatusMessage("certificateStatusMessage")
+            .certificateUpdatedBy("certificateUpdatedBy")
+            .certificateUpdatedAt(123456789L)
+            .announcementTitle("announcementTitle")
+            .announcementMessage("announcementMessage")
+            .announcementUpdatedAt(123456789L)
+            .announcementUpdatedBy("announcementUpdatedBy")
+            .announcementType(AtlanAnnouncementType.INFORMATION)
+            .ownerUser("ownerUser")
+            .ownerGroup("ownerGroup")
+            .adminUser("adminUser")
+            .adminGroup("adminGroup")
+            .adminRole("adminRole")
+            .viewerUser("viewerUser")
+            .viewerGroup("viewerGroup")
+            .connectorType(AtlanConnectorType.PRESTO)
+            .connectionName("connectionName")
+            .connectionQualifiedName("connectionQualifiedName")
+            .hasLineage(false)
+            .isDiscoverable(true)
+            .isEditable(true)
+            .viewScore(123456.0)
+            .popularityScore(123456.0)
+            .sourceOwners("sourceOwners")
+            .sourceURL("sourceURL")
+            .sourceEmbedURL("sourceEmbedURL")
+            .lastSyncWorkflowName("lastSyncWorkflowName")
+            .lastSyncRunAt(123456789L)
+            .lastSyncRun("lastSyncRun")
+            .sourceCreatedBy("sourceCreatedBy")
+            .sourceCreatedAt(123456789L)
+            .sourceUpdatedAt(123456789L)
+            .sourceUpdatedBy("sourceUpdatedBy")
+            .dbtQualifiedName("dbtQualifiedName")
+            .assetDbtAlias("assetDbtAlias")
+            .assetDbtMeta("assetDbtMeta")
+            .assetDbtUniqueId("assetDbtUniqueId")
+            .assetDbtAccountName("assetDbtAccountName")
+            .assetDbtProjectName("assetDbtProjectName")
+            .assetDbtPackageName("assetDbtPackageName")
+            .assetDbtJobName("assetDbtJobName")
+            .assetDbtJobSchedule("assetDbtJobSchedule")
+            .assetDbtJobStatus("assetDbtJobStatus")
+            .assetDbtJobScheduleCronHumanized("assetDbtJobScheduleCronHumanized")
+            .assetDbtJobLastRun(123456789L)
+            .assetDbtJobLastRunUrl("assetDbtJobLastRunUrl")
+            .assetDbtJobLastRunCreatedAt(123456789L)
+            .assetDbtJobLastRunUpdatedAt(123456789L)
+            .assetDbtJobLastRunDequedAt(123456789L)
+            .assetDbtJobLastRunStartedAt(123456789L)
+            .assetDbtJobLastRunTotalDuration("assetDbtJobLastRunTotalDuration")
+            .assetDbtJobLastRunTotalDurationHumanized("assetDbtJobLastRunTotalDurationHumanized")
+            .assetDbtJobLastRunQueuedDuration("assetDbtJobLastRunQueuedDuration")
+            .assetDbtJobLastRunQueuedDurationHumanized("assetDbtJobLastRunQueuedDurationHumanized")
+            .assetDbtJobLastRunRunDuration("assetDbtJobLastRunRunDuration")
+            .assetDbtJobLastRunRunDurationHumanized("assetDbtJobLastRunRunDurationHumanized")
+            .assetDbtJobLastRunGitBranch("assetDbtJobLastRunGitBranch")
+            .assetDbtJobLastRunGitSha("assetDbtJobLastRunGitSha")
+            .assetDbtJobLastRunStatusMessage("assetDbtJobLastRunStatusMessage")
+            .assetDbtJobLastRunOwnerThreadId("assetDbtJobLastRunOwnerThreadId")
+            .assetDbtJobLastRunExecutedByThreadId("assetDbtJobLastRunExecutedByThreadId")
+            .assetDbtJobLastRunArtifactsSaved(true)
+            .assetDbtJobLastRunArtifactS3Path("assetDbtJobLastRunArtifactS3Path")
+            .assetDbtJobLastRunHasDocsGenerated(false)
+            .assetDbtJobLastRunHasSourcesGenerated(true)
+            .assetDbtJobLastRunNotificationsSent(false)
+            .assetDbtJobNextRun(123456789L)
+            .assetDbtJobNextRunHumanized("assetDbtJobNextRunHumanized")
+            .assetDbtEnvironmentName("assetDbtEnvironmentName")
+            .assetDbtEnvironmentDbtVersion("assetDbtEnvironmentDbtVersion")
+            .assetDbtTag("assetDbtTag1")
+            .assetDbtTag("assetDbtTag2")
+            .assetDbtSemanticLayerProxyUrl("assetDbtSemanticLayerProxyUrl")
+            .link(Link.refByGuid("linkGuid1"))
+            .link(Link.refByGuid("linkGuid2"))
+            .readme(Readme.refByGuid("readmeGuid"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid1"))
+            .assignedTerm(GlossaryTerm.refByGuid("termGuid2"))
+            .inputToProcesses(Set.of(
+                    LineageProcess.refByGuid("96671e0f-797b-412b-9ede-c2e35277949c"),
+                    LineageProcess.refByGuid("f2a4125c-c9ca-45dc-b0ff-b33d049d940a")))
+            .outputFromProcesses(Set.of(
+                    LineageProcess.refByGuid("86e50784-0c00-449d-8249-4ac51f1a3d90"),
+                    LineageProcess.refByGuid("8f90fc83-c497-4f3d-b3ce-0fce1029a04c")))
+            .qlikId("qlikId")
+            .qlikQRI("qlikQRI")
+            .qlikSpaceId("qlikSpaceId")
+            .qlikSpaceQualifiedName("qlikSpaceQualifiedName")
+            .qlikAppId("qlikAppId")
+            .qlikAppQualifiedName("qlikAppQualifiedName")
+            .qlikOwnerId("qlikOwnerId")
+            .qlikIsPublished(false)
+            .qlikSpaceType("qlikSpaceType")
+            .qlikDatasets(Set.of(
+                    QlikDataset.refByGuid("927928a7-47c9-4401-9def-fd6725c843e4"),
+                    QlikDataset.refByGuid("11d205cd-5b3f-41a2-8a62-c0a5e43a331b")))
+            .qlikApps(Set.of(
+                    QlikApp.refByGuid("fcf74941-3744-49be-b9ce-12a6847b1c3a"),
+                    QlikApp.refByGuid("5c229bfa-40f0-4b37-8ff8-3f0c2de70d46")))
+            .build();
+    private static QlikSpace frodo;
+    private static String serialized;
+
+    @Test(groups = {"builderEquivalency"})
+    void builderEquivalency() {
+        assertEquals(full.toBuilder().build(), full);
+    }
+
+    @Test(
+            groups = {"serialize"},
+            dependsOnGroups = {"builderEquivalency"})
+    void serialization() {
+        assertNotNull(full);
+        serialized = full.toJson();
+        assertNotNull(serialized);
+    }
+
+    @Test(
+            groups = {"deserialize"},
+            dependsOnGroups = {"serialize"})
+    void deserialization() throws JsonProcessingException {
+        assertNotNull(serialized);
+        frodo = Serde.mapper.readValue(serialized, QlikSpace.class);
+        assertNotNull(frodo);
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void serializedEquivalency() {
+        assertNotNull(serialized);
+        assertNotNull(frodo);
+        String backAgain = frodo.toJson();
+        assertEquals(backAgain, serialized, "Serialization is not equivalent after serde loop,");
+    }
+
+    @Test(
+            groups = {"equivalency"},
+            dependsOnGroups = {"serialize", "deserialize"})
+    void deserializedEquivalency() {
+        assertNotNull(full);
+        assertNotNull(frodo);
+        assertEquals(frodo, full, "Deserialization is not equivalent after serde loop,");
+    }
+}


### PR DESCRIPTION
Additions:

- Adds Qlik types

Fixes:

- Fixes custom metadata creation (due to changes to defaults behind-the-scenes)

Breaking:

- Renames `sqlAsset` property in `DbtSource` to `primarySqlAsset` — to allow multiplicity (new `sqlAssets` property) with builder-based pattern