### PR TITLE
Model updates

### DIFF
--- a/src/main/java/com/atlan/model/assets/ADLS.java
+++ b/src/main/java/com/atlan/model/assets/ADLS.java
@@ -22,4 +22,8 @@ import lombok.experimental.SuperBuilder;
 public abstract class ADLS extends Azure {
 
     public static final String TYPE_NAME = "ADLS";
+
+    /** TBC */
+    @Attribute
+    String adlsAccountQualifiedName;
 }

--- a/src/main/java/com/atlan/model/assets/ADLSAccount.java
+++ b/src/main/java/com/atlan/model/assets/ADLSAccount.java
@@ -66,10 +66,6 @@ public class ADLSAccount extends ADLS {
 
     /** TBC */
     @Attribute
-    Long adlsAccountCreationTime;
-
-    /** TBC */
-    @Attribute
     ADLSProvisionState adlsAccountProvisionState;
 
     /** TBC */

--- a/src/main/java/com/atlan/model/assets/ADLSContainer.java
+++ b/src/main/java/com/atlan/model/assets/ADLSContainer.java
@@ -39,10 +39,6 @@ public class ADLSContainer extends ADLS {
 
     /** TBC */
     @Attribute
-    Long adlsContainerLastModifiedTime;
-
-    /** TBC */
-    @Attribute
     ADLSLeaseState adlsContainerLeaseState;
 
     /** TBC */
@@ -56,6 +52,10 @@ public class ADLSContainer extends ADLS {
     /** TBC */
     @Attribute
     Boolean adlsContainerVersionLevelImmutabilitySupport;
+
+    /** TBC */
+    @Attribute
+    Integer adlsObjectCount;
 
     /** Objects that exist within this container. */
     @Attribute

--- a/src/main/java/com/atlan/model/assets/ADLSObject.java
+++ b/src/main/java/com/atlan/model/assets/ADLSObject.java
@@ -40,14 +40,6 @@ public class ADLSObject extends ADLS {
 
     /** TBC */
     @Attribute
-    Long adlsObjectCreationTime;
-
-    /** TBC */
-    @Attribute
-    Long adlsObjectLastModifiedTime;
-
-    /** TBC */
-    @Attribute
     String adlsObjectVersionId;
 
     /** TBC */
@@ -106,6 +98,10 @@ public class ADLSObject extends ADLS {
     @Attribute
     @Singular("putAdlsObjectMetadata")
     Map<String, String> adlsObjectMetadata;
+
+    /** TBC */
+    @Attribute
+    String adlsContainerQualifiedName;
 
     /** Container this object exists within. */
     @Attribute

--- a/src/main/java/com/atlan/model/assets/Column.java
+++ b/src/main/java/com/atlan/model/assets/Column.java
@@ -117,7 +117,7 @@ public class Column extends SQL {
     @Singular
     Map<String, String> validations;
 
-    /** TBC */
+    /** Number of rows that contain distinct values. */
     @Attribute
     Integer columnDistinctValuesCount;
 
@@ -125,35 +125,35 @@ public class Column extends SQL {
     @Attribute
     Long columnDistinctValuesCountLong;
 
-    /** TBC */
+    /** List of values in a histogram that represents the contents of the column. */
     @Attribute
     Histogram columnHistogram;
 
-    /** TBC */
+    /** Greatest value in a numeric column. */
     @Attribute
     Double columnMax;
 
-    /** TBC */
+    /** Least value in a numeric column. */
     @Attribute
     Double columnMin;
 
-    /** TBC */
+    /** Arithmetic mean of the values in a numeric column. */
     @Attribute
     Double columnMean;
 
-    /** TBC */
+    /** Calculated sum of the values in a numeric column. */
     @Attribute
     Double columnSum;
 
-    /** TBC */
+    /** Calculated median of the values in a numeric column. */
     @Attribute
     Double columnMedian;
 
-    /** TBC */
+    /** Calculated standard deviation of the values in a numeric column. */
     @Attribute
     Double columnStandardDeviation;
 
-    /** TBC */
+    /** Number of rows in which a value in this column appears only once. */
     @Attribute
     Integer columnUniqueValuesCount;
 
@@ -165,11 +165,11 @@ public class Column extends SQL {
     @Attribute
     Double columnAverage;
 
-    /** TBC */
+    /** Average length of values in a string column. */
     @Attribute
     Double columnAverageLength;
 
-    /** TBC */
+    /** Number of rows that contain duplicate values. */
     @Attribute
     Integer columnDuplicateValuesCount;
 
@@ -177,25 +177,25 @@ public class Column extends SQL {
     @Attribute
     Long columnDuplicateValuesCountLong;
 
-    /** TBC */
+    /** Length of the longest value in a string column. */
     @Attribute
     Integer columnMaximumStringLength;
 
-    /** TBC */
+    /** List of the greatest values in a column. */
     @Attribute
     @Singular
     SortedSet<String> columnMaxs;
 
-    /** TBC */
+    /** Length of the shortest value in a string column. */
     @Attribute
     Integer columnMinimumStringLength;
 
-    /** TBC */
+    /** List of the least values in a column. */
     @Attribute
     @Singular
     SortedSet<String> columnMins;
 
-    /** TBC */
+    /** Number of rows in a column that do not contain content. */
     @Attribute
     Integer columnMissingValuesCount;
 
@@ -203,15 +203,15 @@ public class Column extends SQL {
     @Attribute
     Long columnMissingValuesCountLong;
 
-    /** TBC */
+    /** Percentage of rows in a column that do not contain content. */
     @Attribute
     Double columnMissingValuesPercentage;
 
-    /** TBC */
+    /** Ratio indicating how unique data in the column is: 0 indicates that all values are the same, 100 indicates that all values in the column are unique. */
     @Attribute
     Double columnUniquenessPercentage;
 
-    /** TBC */
+    /** Calculated variance of the values in a numeric column. */
     @Attribute
     Double columnVariance;
 

--- a/src/main/java/com/atlan/model/assets/DbtModel.java
+++ b/src/main/java/com/atlan/model/assets/DbtModel.java
@@ -8,6 +8,7 @@ import com.atlan.exception.InvalidRequestException;
 import com.atlan.exception.NotFoundException;
 import com.atlan.model.enums.*;
 import com.atlan.model.relations.UniqueAttributes;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.SortedSet;
@@ -96,7 +97,8 @@ public class DbtModel extends Dbt {
 
     /** TBC */
     @Attribute
-    SQL sqlAsset;
+    @JsonProperty("sqlAsset")
+    SQL primarySqlAsset;
 
     /**
      * Reference to a DbtModel by GUID.

--- a/src/main/java/com/atlan/model/enums/KeywordFields.java
+++ b/src/main/java/com/atlan/model/enums/KeywordFields.java
@@ -20,6 +20,8 @@ public enum KeywordFields implements AtlanSearchableField {
     /** TBC */
     ADLS_ACCOUNT_PROVISION_STATE("adlsAccountProvisionState"),
     /** TBC */
+    ADLS_ACCOUNT_QUALIFIED_NAME("adlsAccountQualifiedName"),
+    /** TBC */
     ADLS_ACCOUNT_REPLICATION("adlsAccountReplication"),
     /** TBC */
     ADLS_ACCOUNT_RESOURCE_GROUP("adlsAccountResourceGroup.keyword"),
@@ -33,6 +35,8 @@ public enum KeywordFields implements AtlanSearchableField {
     ADLS_CONTAINER_LEASE_STATE("adlsContainerLeaseState"),
     /** TBC */
     ADLS_CONTAINER_LEASE_STATUS("adlsContainerLeaseStatus"),
+    /** TBC */
+    ADLS_CONTAINER_QUALIFIED_NAME("adlsContainerQualifiedName"),
     /** TBC */
     ADLS_CONTAINER_URL("adlsContainerUrl.keyword"),
     /** Entity tag for the asset. An entity tag is a hash of the object and represents changes to the contents of an object only, not its metadata. */
@@ -217,11 +221,11 @@ public enum KeywordFields implements AtlanSearchableField {
     CODE("code"),
     /** qualifiedName of the collection in which this folder exists. */
     COLLECTION_QUALIFIED_NAME("collectionQualifiedName"),
-    /** TBC */
+    /** List of values in a histogram that represents the contents of the column. */
     COLUMN_HISTOGRAM("columnHistogram"),
-    /** TBC */
+    /** List of the greatest values in a column. */
     COLUMN_MAXS("columnMaxs"),
-    /** TBC */
+    /** List of the least values in a column. */
     COLUMN_MINS("columnMins"),
     /** TBC */
     COLUMN_TOP_VALUES("columnTopValues"),
@@ -442,7 +446,7 @@ public enum KeywordFields implements AtlanSearchableField {
     /** TBC */
     LOOKML_LINK_ID("lookmlLinkId"),
     /** All terms attached to an asset, searchable by the term's qualifiedName. */
-    MEANINGS("__meanings"),
+    ASSIGNED_TERMS("__meanings"),
     /** TBC */
     MERGE_RESULT_ID("mergeResultId"),
     /** TBC */

--- a/src/main/java/com/atlan/model/enums/NumericFields.java
+++ b/src/main/java/com/atlan/model/enums/NumericFields.java
@@ -6,15 +6,9 @@ import lombok.Getter;
 
 public enum NumericFields implements AtlanSearchableField {
     /** TBC */
-    ADLS_ACCOUNT_CREATION_TIME("adlsAccountCreationTime"),
-    /** TBC */
-    ADLS_CONTAINER_LAST_MODIFIED_TIME("adlsContainerLastModifiedTime"),
-    /** TBC */
     ADLS_OBJECT_ACCESS_TIER_LAST_MODIFIED_TIME("adlsObjectAccessTierLastModifiedTime"),
     /** TBC */
-    ADLS_OBJECT_CREATION_TIME("adlsObjectCreationTime"),
-    /** TBC */
-    ADLS_OBJECT_LAST_MODIFIED_TIME("adlsObjectLastModifiedTime"),
+    ADLS_OBJECT_COUNT("adlsObjectCount"),
     /** TBC */
     ADLS_OBJECT_SIZE("adlsObjectSize"),
     /** Time (epoch) at which the announcement was last updated, in milliseconds. */
@@ -35,47 +29,47 @@ public enum NumericFields implements AtlanSearchableField {
     CERTIFICATE_UPDATED_AT("certificateUpdatedAt"),
     /** TBC */
     COLUMN_AVERAGE("columnAverage"),
-    /** TBC */
+    /** Average length of values in a string column. */
     COLUMN_AVERAGE_LENGTH("columnAverageLength"),
     /** Number of columns in this view. */
     COLUMN_COUNT("columnCount"),
-    /** TBC */
+    /** Number of rows that contain distinct values. */
     COLUMN_DISTINCT_VALUES_COUNT("columnDistinctValuesCount"),
     /** TBC */
     COLUMN_DISTINCT_VALUES_COUNT_LONG("columnDistinctValuesCountLong"),
-    /** TBC */
+    /** Number of rows that contain duplicate values. */
     COLUMN_DUPLICATE_VALUES_COUNT("columnDuplicateValuesCount"),
     /** TBC */
     COLUMN_DUPLICATE_VALUES_COUNT_LONG("columnDuplicateValuesCountLong"),
-    /** TBC */
+    /** Greatest value in a numeric column. */
     COLUMN_MAX("columnMax"),
-    /** TBC */
+    /** Length of the longest value in a string column. */
     COLUMN_MAXIMUM_STRING_LENGTH("columnMaximumStringLength"),
-    /** TBC */
+    /** Arithmetic mean of the values in a numeric column. */
     COLUMN_MEAN("columnMean"),
-    /** TBC */
+    /** Calculated median of the values in a numeric column. */
     COLUMN_MEDIAN("columnMedian"),
-    /** TBC */
+    /** Least value in a numeric column. */
     COLUMN_MIN("columnMin"),
-    /** TBC */
+    /** Length of the shortest value in a string column. */
     COLUMN_MINIMUM_STRING_LENGTH("columnMinimumStringLength"),
-    /** TBC */
+    /** Number of rows in a column that do not contain content. */
     COLUMN_MISSING_VALUES_COUNT("columnMissingValuesCount"),
     /** TBC */
     COLUMN_MISSING_VALUES_COUNT_LONG("columnMissingValuesCountLong"),
-    /** TBC */
+    /** Percentage of rows in a column that do not contain content. */
     COLUMN_MISSING_VALUES_PERCENTAGE("columnMissingValuesPercentage"),
-    /** TBC */
+    /** Calculated standard deviation of the values in a numeric column. */
     COLUMN_STANDARD_DEVIATION("columnStandardDeviation"),
-    /** TBC */
+    /** Calculated sum of the values in a numeric column. */
     COLUMN_SUM("columnSum"),
-    /** TBC */
+    /** Number of rows in which a value in this column appears only once. */
     COLUMN_UNIQUE_VALUES_COUNT("columnUniqueValuesCount"),
     /** TBC */
     COLUMN_UNIQUE_VALUES_COUNT_LONG("columnUniqueValuesCountLong"),
-    /** TBC */
+    /** Ratio indicating how unique data in the column is: 0 indicates that all values are the same, 100 indicates that all values in the column are unique. */
     COLUMN_UNIQUENESS_PERCENTAGE("columnUniquenessPercentage"),
-    /** TBC */
+    /** Calculated variance of the values in a numeric column. */
     COLUMN_VARIANCE("columnVariance"),
     /** TBC */
     DASHBOARD_COUNT("dashboardCount"),

--- a/src/main/java/com/atlan/model/enums/TextFields.java
+++ b/src/main/java/com/atlan/model/enums/TextFields.java
@@ -6,9 +6,13 @@ import lombok.Getter;
 
 public enum TextFields implements AtlanSearchableField {
     /** TBC */
+    ADLS_ACCOUNT_QUALIFIED_NAME("adlsAccountQualifiedName.text"),
+    /** TBC */
     ADLS_ACCOUNT_RESOURCE_GROUP("adlsAccountResourceGroup"),
     /** TBC */
     ADLS_ACCOUNT_SUBSCRIPTION("adlsAccountSubscription"),
+    /** TBC */
+    ADLS_CONTAINER_QUALIFIED_NAME("adlsContainerQualifiedName.text"),
     /** TBC */
     ADLS_CONTAINER_URL("adlsContainerUrl"),
     /** TBC */

--- a/src/main/java/com/atlan/util/QueryFactory.java
+++ b/src/main/java/com/atlan/util/QueryFactory.java
@@ -122,7 +122,7 @@ public class QueryFactory {
      * @return a query that will only match assets that have at least one term assigned
      */
     public static Query beAssignedATerm() {
-        return have(KeywordFields.MEANINGS).present();
+        return have(KeywordFields.ASSIGNED_TERMS).present();
     }
 
     /**
@@ -132,7 +132,7 @@ public class QueryFactory {
      * @return a query that will only match assets that have at least one of the terms assigned
      */
     public static Query beDefinedByAtLeastOneOf(Collection<String> termQualifiedNames) {
-        return have(KeywordFields.MEANINGS).beOneOf(termQualifiedNames);
+        return have(KeywordFields.ASSIGNED_TERMS).beOneOf(termQualifiedNames);
     }
 
     /**

--- a/src/test/java/com/atlan/model/assets/ADLSAccountTest.java
+++ b/src/test/java/com/atlan/model/assets/ADLSAccountTest.java
@@ -124,7 +124,6 @@ public class ADLSAccountTest {
             .adlsAccountReplication(ADLSReplicationType.READ_ACCESS_GEO_REDUNDANT)
             .adlsAccountKind(ADLSStorageKind.FILE)
             .adlsPrimaryDiskState(ADLSAccountStatus.AVAILABLE)
-            .adlsAccountCreationTime(3547019824354036828L)
             .adlsAccountProvisionState(ADLSProvisionState.SUCCEEDED)
             .adlsAccountAccessTier(ADLSAccessTier.HOT)
             .adlsContainers(Set.of(

--- a/src/test/java/com/atlan/model/assets/ADLSContainerTest.java
+++ b/src/test/java/com/atlan/model/assets/ADLSContainerTest.java
@@ -117,7 +117,6 @@ public class ADLSContainerTest {
                     LineageProcess.refByGuid("59ac2904-7975-4711-ba90-1b28ec39043b"),
                     LineageProcess.refByGuid("a64a931e-d7ad-459e-87a4-f863d0412bcf")))
             .adlsContainerUrl("adlsContainerUrl")
-            .adlsContainerLastModifiedTime(8690434353178190950L)
             .adlsContainerLeaseState(ADLSLeaseState.AVAILABLE)
             .adlsContainerLeaseStatus(ADLSLeaseStatus.UNLOCKED)
             .adlsContainerEncryptionScope("adlsContainerEncryptionScope")

--- a/src/test/java/com/atlan/model/assets/ADLSObjectTest.java
+++ b/src/test/java/com/atlan/model/assets/ADLSObjectTest.java
@@ -117,8 +117,6 @@ public class ADLSObjectTest {
                     LineageProcess.refByGuid("59b3617c-a3a4-41ce-8ed6-91c8bc653e6e"),
                     LineageProcess.refByGuid("25cd62c7-8120-4c6d-a1f0-d45c75efbe46")))
             .adlsObjectUrl("adlsObjectUrl")
-            .adlsObjectCreationTime(-1312082568702260409L)
-            .adlsObjectLastModifiedTime(-8595234611958779974L)
             .adlsObjectVersionId("adlsObjectVersionId")
             .adlsObjectType(ADLSObjectType.APPEND_BLOB)
             .adlsObjectSize(-4522292454635227782L)

--- a/src/test/java/com/atlan/model/assets/DbtModelTest.java
+++ b/src/test/java/com/atlan/model/assets/DbtModelTest.java
@@ -149,7 +149,7 @@ public class DbtModelTest {
             .dbtModelColumns(Set.of(
                     DbtModelColumn.refByGuid("c4a8caac-33c8-4e60-b54d-bd1c2649c27a"),
                     DbtModelColumn.refByGuid("c3744b50-51dd-40a4-a200-e74da1f5f14e")))
-            .sqlAsset(Table.refByGuid("779cce78-3d9a-479a-9efe-b61b4b95c5ef"))
+            .primarySqlAsset(Table.refByGuid("779cce78-3d9a-479a-9efe-b61b4b95c5ef"))
             .build();
     private static DbtModel frodo;
     private static String serialized;


### PR DESCRIPTION
Breaking:

- Renames `MEANINGS` searchable fields enum to `ASSIGNED_TERMS`
- Aligns model with ADLS model changes (some attributes removed due to overlap with out-of-the-box attributes)
