### PR TITLE
Various fixes and enhancements

### DIFF
--- a/src/liveTest/java/com/atlan/live/ADLSAssetTest.java
+++ b/src/liveTest/java/com/atlan/live/ADLSAssetTest.java
@@ -30,8 +30,8 @@ public class ADLSAssetTest extends AtlanLiveTest {
 
     private static final String PREFIX = "ADLSAssetTest";
 
-    private static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.ADLS;
-    private static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
+    public static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.ADLS;
+    public static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
     private static final String ACCOUNT_NAME = PREFIX + "-account";
     private static final String CONTAINER_NAME = PREFIX + "-container";
     private static final String OBJECT_NAME = PREFIX + "-object.csv";

--- a/src/liveTest/java/com/atlan/live/APIAssetTest.java
+++ b/src/liveTest/java/com/atlan/live/APIAssetTest.java
@@ -25,8 +25,8 @@ public class APIAssetTest extends AtlanLiveTest {
 
     private static final String PREFIX = "APIAssetTest";
 
-    private static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.API;
-    private static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
+    public static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.API;
+    public static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
     private static final String SPEC_NAME = PREFIX + "-spec";
     private static final String PATH_NAME = "/api/" + PREFIX;
 

--- a/src/liveTest/java/com/atlan/live/ConnectionTest.java
+++ b/src/liveTest/java/com/atlan/live/ConnectionTest.java
@@ -74,7 +74,7 @@ public class ConnectionTest extends AtlanLiveTest {
      * @throws AtlanException on any errors deleting the connection
      * @throws InterruptedException if the busy-wait loop for monitoring is interuppted
      */
-    static void deleteConnection(String qualifiedName, Logger log) throws AtlanException, InterruptedException {
+    public static void deleteConnection(String qualifiedName, Logger log) throws AtlanException, InterruptedException {
         try {
             Workflow deleteWorkflow = ConnectionDelete.creator(qualifiedName, true);
             WorkflowResponse response = deleteWorkflow.run();

--- a/src/liveTest/java/com/atlan/live/DataStudioAssetTest.java
+++ b/src/liveTest/java/com/atlan/live/DataStudioAssetTest.java
@@ -28,8 +28,8 @@ public class DataStudioAssetTest extends AtlanLiveTest {
 
     private static final String PREFIX = "DataStudioAssetTest";
 
-    private static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.DATASTUDIO;
-    private static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
+    public static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.DATASTUDIO;
+    public static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
     private static final String REPORT_NAME = PREFIX + "-report";
     private static final String SOURCE_NAME = PREFIX + "-source";
 

--- a/src/liveTest/java/com/atlan/live/GCSAssetTest.java
+++ b/src/liveTest/java/com/atlan/live/GCSAssetTest.java
@@ -30,8 +30,8 @@ public class GCSAssetTest extends AtlanLiveTest {
 
     private static final String PREFIX = "GCSAssetTest";
 
-    private static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.GCS;
-    private static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
+    public static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.GCS;
+    public static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
     private static final String BUCKET_NAME = PREFIX + "-bucket";
     private static final String OBJECT_NAME = PREFIX + "-object.csv";
 

--- a/src/liveTest/java/com/atlan/live/GlossaryTest.java
+++ b/src/liveTest/java/com/atlan/live/GlossaryTest.java
@@ -401,7 +401,8 @@ public class GlossaryTest extends AtlanLiveTest {
         assertEquals(g.getAnnouncementType(), ANNOUNCEMENT_TYPE);
         assertEquals(g.getAnnouncementTitle(), ANNOUNCEMENT_TITLE);
         assertEquals(g.getAnnouncementMessage(), ANNOUNCEMENT_MESSAGE);
-        g = Glossary.updateCertificate(glossary.getQualifiedName(), GLOSSARY_NAME, CERTIFICATE_STATUS, CERTIFICATE_MESSAGE);
+        g = Glossary.updateCertificate(
+                glossary.getQualifiedName(), GLOSSARY_NAME, CERTIFICATE_STATUS, CERTIFICATE_MESSAGE);
         assertEquals(g.getCertificateStatus(), CERTIFICATE_STATUS);
         assertEquals(g.getCertificateStatusMessage(), CERTIFICATE_MESSAGE);
     }
@@ -429,7 +430,12 @@ public class GlossaryTest extends AtlanLiveTest {
         assertEquals(c.getAnnouncementType(), ANNOUNCEMENT_TYPE);
         assertEquals(c.getAnnouncementTitle(), ANNOUNCEMENT_TITLE);
         assertEquals(c.getAnnouncementMessage(), ANNOUNCEMENT_MESSAGE);
-        c = GlossaryCategory.updateCertificate(category.getQualifiedName(), category.getName(), glossary.getGuid(), CERTIFICATE_STATUS, CERTIFICATE_MESSAGE);
+        c = GlossaryCategory.updateCertificate(
+                category.getQualifiedName(),
+                category.getName(),
+                glossary.getGuid(),
+                CERTIFICATE_STATUS,
+                CERTIFICATE_MESSAGE);
         assertEquals(c.getCertificateStatus(), CERTIFICATE_STATUS);
         assertEquals(c.getCertificateStatusMessage(), CERTIFICATE_MESSAGE);
     }

--- a/src/liveTest/java/com/atlan/live/GlossaryTest.java
+++ b/src/liveTest/java/com/atlan/live/GlossaryTest.java
@@ -387,8 +387,6 @@ public class GlossaryTest extends AtlanLiveTest {
             dependsOnGroups = {"read.glossary"})
     void updateGlossary() throws AtlanException {
         Glossary g = Glossary.updater(glossary.getGuid(), GLOSSARY_NAME)
-                .certificateStatus(CERTIFICATE_STATUS)
-                .certificateStatusMessage(CERTIFICATE_MESSAGE)
                 .announcementType(ANNOUNCEMENT_TYPE)
                 .announcementTitle(ANNOUNCEMENT_TITLE)
                 .announcementMessage(ANNOUNCEMENT_MESSAGE)
@@ -400,11 +398,12 @@ public class GlossaryTest extends AtlanLiveTest {
         assertEquals(g.getGuid(), glossary.getGuid());
         assertEquals(g.getQualifiedName(), glossary.getQualifiedName());
         assertEquals(g.getName(), glossary.getName());
-        assertEquals(g.getCertificateStatus(), CERTIFICATE_STATUS);
-        assertEquals(g.getCertificateStatusMessage(), CERTIFICATE_MESSAGE);
         assertEquals(g.getAnnouncementType(), ANNOUNCEMENT_TYPE);
         assertEquals(g.getAnnouncementTitle(), ANNOUNCEMENT_TITLE);
         assertEquals(g.getAnnouncementMessage(), ANNOUNCEMENT_MESSAGE);
+        g = Glossary.updateCertificate(glossary.getQualifiedName(), GLOSSARY_NAME, CERTIFICATE_STATUS, CERTIFICATE_MESSAGE);
+        assertEquals(g.getCertificateStatus(), CERTIFICATE_STATUS);
+        assertEquals(g.getCertificateStatusMessage(), CERTIFICATE_MESSAGE);
     }
 
     @Test(
@@ -416,8 +415,6 @@ public class GlossaryTest extends AtlanLiveTest {
                         category.getQualifiedName(),
                         category.getName(),
                         category.getAnchor().getGuid())
-                .certificateStatus(CERTIFICATE_STATUS)
-                .certificateStatusMessage(CERTIFICATE_MESSAGE)
                 .announcementType(ANNOUNCEMENT_TYPE)
                 .announcementTitle(ANNOUNCEMENT_TITLE)
                 .announcementMessage(ANNOUNCEMENT_MESSAGE)
@@ -429,11 +426,12 @@ public class GlossaryTest extends AtlanLiveTest {
         assertEquals(c.getGuid(), category.getGuid());
         assertEquals(c.getQualifiedName(), category.getQualifiedName());
         assertEquals(c.getName(), category.getName());
-        assertEquals(c.getCertificateStatus(), CERTIFICATE_STATUS);
-        assertEquals(c.getCertificateStatusMessage(), CERTIFICATE_MESSAGE);
         assertEquals(c.getAnnouncementType(), ANNOUNCEMENT_TYPE);
         assertEquals(c.getAnnouncementTitle(), ANNOUNCEMENT_TITLE);
         assertEquals(c.getAnnouncementMessage(), ANNOUNCEMENT_MESSAGE);
+        c = GlossaryCategory.updateCertificate(category.getQualifiedName(), category.getName(), glossary.getGuid(), CERTIFICATE_STATUS, CERTIFICATE_MESSAGE);
+        assertEquals(c.getCertificateStatus(), CERTIFICATE_STATUS);
+        assertEquals(c.getCertificateStatusMessage(), CERTIFICATE_MESSAGE);
     }
 
     @Test(

--- a/src/liveTest/java/com/atlan/live/LineageTest.java
+++ b/src/liveTest/java/com/atlan/live/LineageTest.java
@@ -33,8 +33,8 @@ public class LineageTest extends AtlanLiveTest {
 
     private static final String PREFIX = "LineageTest";
 
-    private static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.VERTICA;
-    private static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
+    public static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.VERTICA;
+    public static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
     private static final String DATABASE_NAME = PREFIX + "_db";
     private static final String SCHEMA_NAME = PREFIX + "_schema";
     private static final String TABLE_NAME = PREFIX + "_tbl";

--- a/src/liveTest/java/com/atlan/live/PersonaTest.java
+++ b/src/liveTest/java/com/atlan/live/PersonaTest.java
@@ -66,7 +66,7 @@ public class PersonaTest extends AtlanLiveTest {
             groups = {"update.personas"},
             dependsOnGroups = {"create.personas"})
     void updatePersonas() throws AtlanException {
-        Persona persona = Persona.updater(personaGuid, PERSONA_NAME)
+        Persona persona = Persona.retrieveByName(PERSONA_NAME).toBuilder()
                 .description("Now with a description!")
                 .attributes(Persona.PersonaAttributes.builder()
                         .preferences(Persona.PersonaPreferences.builder()

--- a/src/liveTest/java/com/atlan/live/PersonaTest.java
+++ b/src/liveTest/java/com/atlan/live/PersonaTest.java
@@ -21,8 +21,8 @@ public class PersonaTest extends AtlanLiveTest {
     private static final String PREFIX = "PersonaTest";
 
     private static final String PERSONA_NAME = PREFIX;
-    private static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
-    private static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.GCS;
+    public static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
+    public static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.GCS;
     private static final String GLOSSARY_NAME = PREFIX;
 
     private static String personaGuid = null;

--- a/src/liveTest/java/com/atlan/live/PurposeTest.java
+++ b/src/liveTest/java/com/atlan/live/PurposeTest.java
@@ -72,7 +72,9 @@ public class PurposeTest extends AtlanLiveTest {
             groups = {"update.purposes"},
             dependsOnGroups = {"create.purposes"})
     void updatePurposes() throws AtlanException {
-        Purpose purpose = Purpose.updater(purposeGuid, PURPOSE_NAME, List.of(CLS_NAME))
+        Purpose purpose = Purpose.retrieveByName(PURPOSE_NAME);
+        assertNotNull(purpose);
+        purpose = purpose.toBuilder()
                 .description("Now with a description!")
                 .attributes(Purpose.PurposeAttributes.builder()
                         .preferences(Purpose.PurposePreferences.builder()

--- a/src/liveTest/java/com/atlan/live/S3AssetTest.java
+++ b/src/liveTest/java/com/atlan/live/S3AssetTest.java
@@ -68,10 +68,7 @@ public class S3AssetTest extends AtlanLiveTest {
             groups = {"create.object"},
             dependsOnGroups = {"create.bucket"})
     void createObject() throws AtlanException {
-        S3Object toCreate = S3Object.creator(OBJECT_NAME, connection.getQualifiedName(), OBJECT_ARN)
-                .s3BucketName(BUCKET_NAME)
-                .s3BucketQualifiedName(bucket.getQualifiedName())
-                .bucket(S3Bucket.refByGuid(bucket.getGuid()))
+        S3Object toCreate = S3Object.creator(OBJECT_NAME, bucket.getQualifiedName(), BUCKET_NAME, OBJECT_ARN)
                 .build();
         AssetMutationResponse response = toCreate.upsert();
         assertNotNull(response);

--- a/src/liveTest/java/com/atlan/live/S3AssetTest.java
+++ b/src/liveTest/java/com/atlan/live/S3AssetTest.java
@@ -30,8 +30,8 @@ public class S3AssetTest extends AtlanLiveTest {
 
     private static final String PREFIX = "S3AssetTest";
 
-    private static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.S3;
-    private static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
+    public static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.S3;
+    public static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
 
     private static final String BUCKET_NAME = "mybucket";
     private static final String BUCKET_ARN = "arn:aws:s3:::mybucket";

--- a/src/liveTest/java/com/atlan/live/SQLAssetTest.java
+++ b/src/liveTest/java/com/atlan/live/SQLAssetTest.java
@@ -35,8 +35,8 @@ public class SQLAssetTest extends AtlanLiveTest {
 
     private static final String PREFIX = "SQLAssetTest";
 
-    private static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.SAPHANA;
-    private static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
+    public static final AtlanConnectorType CONNECTOR_TYPE = AtlanConnectorType.SAPHANA;
+    public static final String CONNECTION_NAME = "java-sdk-" + PREFIX;
 
     public static final String DATABASE_NAME = PREFIX + "_db";
     public static final String SCHEMA_NAME = PREFIX + "_schema";

--- a/src/liveTest/java/com/atlan/live/SQLAssetTest.java
+++ b/src/liveTest/java/com/atlan/live/SQLAssetTest.java
@@ -587,7 +587,6 @@ public class SQLAssetTest extends AtlanLiveTest {
     void updateColumnOwnersX() throws AtlanException {
         Column cleared = Column.removeOwners(column5.getQualifiedName(), COLUMN_NAME5);
         validateUpdatedColumn(cleared);
-        log.info("Groups: {}", cleared.getOwnerGroups());
         assertTrue(cleared.getOwnerGroups() == null || cleared.getOwnerGroups().isEmpty());
     }
 

--- a/src/liveTest/java/com/atlan/live/SQLAssetTest.java
+++ b/src/liveTest/java/com/atlan/live/SQLAssetTest.java
@@ -679,7 +679,7 @@ public class SQLAssetTest extends AtlanLiveTest {
             dependsOnGroups = {"create.classifications", "update.column.userDescription.x"})
     void updateClassification() throws AtlanException {
         Column toUpdate = Column.updater(column5.getQualifiedName(), COLUMN_NAME5)
-                .classification(Classification.of(CLASSIFICATION_NAME1, column5.getGuid()))
+                .classification(Classification.of(CLASSIFICATION_NAME1))
                 .build();
         AssetMutationResponse response = toUpdate.upsert(true, false);
         Asset one = validateSingleUpdate(response);

--- a/src/main/java/com/atlan/cache/ClassificationCache.java
+++ b/src/main/java/com/atlan/cache/ClassificationCache.java
@@ -27,7 +27,7 @@ public class ClassificationCache {
     private static Set<String> deletedIds = ConcurrentHashMap.newKeySet();
     private static Set<String> deletedNames = ConcurrentHashMap.newKeySet();
 
-    private static synchronized void refreshCache() throws AtlanException {
+    public static synchronized void refreshCache() throws AtlanException {
         log.debug("Refreshing cache of classifications...");
         TypeDefResponse response = TypeDefsEndpoint.getTypeDefs(AtlanTypeCategory.CLASSIFICATION);
         List<ClassificationDef> classifications;

--- a/src/main/java/com/atlan/model/admin/Persona.java
+++ b/src/main/java/com/atlan/model/admin/Persona.java
@@ -35,7 +35,9 @@ public class Persona extends AtlanObject {
     String displayName;
 
     /** Description of the persona. */
-    String description;
+    @Builder.Default
+    @JsonInclude(JsonInclude.Include.ALWAYS)
+    String description = "";
 
     /** Unique identifiers (GUIDs) of groups that are associated with the persona. */
     @Singular
@@ -57,10 +59,12 @@ public class Persona extends AtlanObject {
 
     /** Set of metadata policies defined for this persona. */
     @Singular
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     SortedSet<PersonaMetadataPolicy> metadataPolicies;
 
     /** Set of data policies defined for this persona. */
     @Singular
+    @JsonInclude(JsonInclude.Include.ALWAYS)
     SortedSet<PersonaDataPolicy> dataPolicies;
 
     /** Set of glossary policies defined for this persona. */

--- a/src/main/java/com/atlan/model/admin/Persona.java
+++ b/src/main/java/com/atlan/model/admin/Persona.java
@@ -35,9 +35,7 @@ public class Persona extends AtlanObject {
     String displayName;
 
     /** Description of the persona. */
-    @Builder.Default
-    @JsonInclude(JsonInclude.Include.ALWAYS)
-    String description = "";
+    String description;
 
     /** Unique identifiers (GUIDs) of groups that are associated with the persona. */
     @Singular
@@ -59,12 +57,10 @@ public class Persona extends AtlanObject {
 
     /** Set of metadata policies defined for this persona. */
     @Singular
-    @JsonInclude(JsonInclude.Include.ALWAYS)
     SortedSet<PersonaMetadataPolicy> metadataPolicies;
 
     /** Set of data policies defined for this persona. */
     @Singular
-    @JsonInclude(JsonInclude.Include.ALWAYS)
     SortedSet<PersonaDataPolicy> dataPolicies;
 
     /** Set of glossary policies defined for this persona. */
@@ -112,17 +108,7 @@ public class Persona extends AtlanObject {
      * @return the minimal request necessary to update the persona, as a builder
      */
     public static PersonaBuilder<?, ?> creator(String name) {
-        return Persona.builder().name(name).displayName(name);
-    }
-
-    /**
-     * Builds the minimal object necessary to update a persona.
-     *
-     * @param id unique identifier (GUID) of the persona
-     * @return the minimal request necessary to update the persona, as a builder
-     */
-    public static PersonaBuilder<?, ?> updater(String id, String name) {
-        return Persona.builder().id(id).name(name);
+        return Persona.builder().name(name).displayName(name).description("");
     }
 
     /**

--- a/src/main/java/com/atlan/model/admin/PersonaDataPolicy.java
+++ b/src/main/java/com/atlan/model/admin/PersonaDataPolicy.java
@@ -49,6 +49,7 @@ public class PersonaDataPolicy extends AbstractPersonaPolicy {
             boolean allow) {
         return PersonaDataPolicy.builder()
                 .name(name)
+                .description("")
                 .connectionId(connectionId)
                 .assets(assetPrefixes)
                 .actions(actions)

--- a/src/main/java/com/atlan/model/admin/PersonaMetadataPolicy.java
+++ b/src/main/java/com/atlan/model/admin/PersonaMetadataPolicy.java
@@ -42,6 +42,7 @@ public class PersonaMetadataPolicy extends AbstractPersonaPolicy {
             boolean allow) {
         return PersonaMetadataPolicy.builder()
                 .name(name)
+                .description("")
                 .connectionId(connectionId)
                 .assets(assetPrefixes)
                 .actions(actions)

--- a/src/main/java/com/atlan/model/admin/Purpose.java
+++ b/src/main/java/com/atlan/model/admin/Purpose.java
@@ -16,10 +16,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-import java.util.Collections;
-import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
+import java.util.*;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
@@ -107,24 +104,12 @@ public class Purpose extends AtlanObject {
         if (classifications == null || classifications.isEmpty()) {
             throw new InvalidRequestException(ErrorCode.NO_CLASSIFICATION_FOR_PURPOSE);
         }
-        return Purpose.builder().name(name).displayName(name).tags(classifications);
-    }
-
-    /**
-     * Builds the minimal object necessary to update a purpose.
-     *
-     * @param id unique identifier (GUID) of the purpose
-     * @param name of the purpose
-     * @param classifications list of human-readable classification names to include in the purpose (must be at least one)
-     * @return the minimal request necessary to update the purpose, as a builder
-     * @throws InvalidRequestException if no classifications have been provided for the purpose
-     */
-    public static PurposeBuilder<?, ?> updater(String id, String name, List<String> classifications)
-            throws InvalidRequestException {
-        if (classifications == null || classifications.isEmpty()) {
-            throw new InvalidRequestException(ErrorCode.NO_CLASSIFICATION_FOR_PURPOSE);
-        }
-        return Purpose.builder().id(id).name(name).tags(classifications);
+        return Purpose.builder()
+                .id(UUID.randomUUID().toString())
+                .name(name)
+                .displayName(name)
+                .description("")
+                .tags(classifications);
     }
 
     /**

--- a/src/main/java/com/atlan/model/admin/PurposeDataPolicy.java
+++ b/src/main/java/com/atlan/model/admin/PurposeDataPolicy.java
@@ -58,6 +58,7 @@ public class PurposeDataPolicy extends AbstractPurposePolicy {
         boolean userSpecified = false;
         PurposeDataPolicyBuilder<?, ?> builder = PurposeDataPolicy.builder()
                 .name(name)
+                .description("")
                 .actions(actions)
                 .type(type)
                 .allow(allow);

--- a/src/main/java/com/atlan/model/admin/PurposeMetadataPolicy.java
+++ b/src/main/java/com/atlan/model/admin/PurposeMetadataPolicy.java
@@ -48,8 +48,11 @@ public class PurposeMetadataPolicy extends AbstractPurposePolicy {
             boolean allow)
             throws InvalidRequestException {
         boolean userSpecified = false;
-        PurposeMetadataPolicyBuilder<?, ?> builder =
-                PurposeMetadataPolicy.builder().name(name).actions(actions).allow(allow);
+        PurposeMetadataPolicyBuilder<?, ?> builder = PurposeMetadataPolicy.builder()
+                .name(name)
+                .description("")
+                .actions(actions)
+                .allow(allow);
         if (allUsers) {
             userSpecified = true;
             builder = builder.allUsers(true);

--- a/src/main/java/com/atlan/model/assets/ADLSContainer.java
+++ b/src/main/java/com/atlan/model/assets/ADLSContainer.java
@@ -102,6 +102,7 @@ public class ADLSContainer extends ADLS {
                 .qualifiedName(accountQualifiedName + "/" + name)
                 .name(name)
                 .adlsAccount(ADLSAccount.refByQualifiedName(accountQualifiedName))
+                .adlsAccountQualifiedName(accountQualifiedName)
                 .connectionQualifiedName(connectionQualifiedName)
                 .connectorType(AtlanConnectorType.ADLS);
     }

--- a/src/main/java/com/atlan/model/assets/ADLSObject.java
+++ b/src/main/java/com/atlan/model/assets/ADLSObject.java
@@ -139,11 +139,12 @@ public class ADLSObject extends ADLS {
      */
     public static ADLSObjectBuilder<?, ?> creator(String name, String containerQualifiedName) {
         String accountQualifiedName = StringUtils.getParentQualifiedNameFromQualifiedName(containerQualifiedName);
-        String connectionQualifiedName = StringUtils.getParentQualifiedNameFromQualifiedName(accountQualifiedName);
+        String connectionQualifiedName = StringUtils.getConnectionQualifiedName(containerQualifiedName);
         return ADLSObject.builder()
                 .qualifiedName(containerQualifiedName + "/" + name)
                 .name(name)
                 .adlsContainer(ADLSContainer.refByQualifiedName(containerQualifiedName))
+                .adlsAccountQualifiedName(accountQualifiedName)
                 .connectionQualifiedName(connectionQualifiedName)
                 .connectorType(AtlanConnectorType.ADLS);
     }

--- a/src/main/java/com/atlan/model/assets/GCSObject.java
+++ b/src/main/java/com/atlan/model/assets/GCSObject.java
@@ -127,7 +127,7 @@ public class GCSObject extends GCS {
      * @return the minimal object necessary to create the GCSObject, as a builder
      */
     public static GCSObjectBuilder<?, ?> creator(String name, String bucketQualifiedName) {
-        String connectionQualifiedName = StringUtils.getParentQualifiedNameFromQualifiedName(bucketQualifiedName);
+        String connectionQualifiedName = StringUtils.getConnectionQualifiedName(bucketQualifiedName);
         String bucketName = StringUtils.getNameFromQualifiedName(bucketQualifiedName);
         return GCSObject.builder()
                 .qualifiedName(bucketQualifiedName + "/" + name)

--- a/src/main/java/com/atlan/model/assets/Glossary.java
+++ b/src/main/java/com/atlan/model/assets/Glossary.java
@@ -452,7 +452,8 @@ public class Glossary extends Asset {
      * @return the updated Glossary, or null if the update failed
      * @throws AtlanException on any API problems
      */
-    public static Glossary updateCertificate(String qualifiedName, String name, AtlanCertificateStatus certificate, String message)
+    public static Glossary updateCertificate(
+            String qualifiedName, String name, AtlanCertificateStatus certificate, String message)
             throws AtlanException {
         return (Glossary) Asset.updateCertificate(builder().name(name), TYPE_NAME, qualifiedName, certificate, message);
     }
@@ -482,8 +483,10 @@ public class Glossary extends Asset {
      * @throws AtlanException on any API problems
      */
     public static Glossary updateAnnouncement(
-            String qualifiedName, String name, AtlanAnnouncementType type, String title, String message) throws AtlanException {
-        return (Glossary) Asset.updateAnnouncement(builder().name(name), TYPE_NAME, qualifiedName, type, title, message);
+            String qualifiedName, String name, AtlanAnnouncementType type, String title, String message)
+            throws AtlanException {
+        return (Glossary)
+                Asset.updateAnnouncement(builder().name(name), TYPE_NAME, qualifiedName, type, title, message);
     }
 
     /**

--- a/src/main/java/com/atlan/model/assets/Glossary.java
+++ b/src/main/java/com/atlan/model/assets/Glossary.java
@@ -446,14 +446,15 @@ public class Glossary extends Asset {
      * Update the certificate on a Glossary.
      *
      * @param qualifiedName of the Glossary
+     * @param name of the Glossary
      * @param certificate to use
      * @param message (optional) message, or null if no message
      * @return the updated Glossary, or null if the update failed
      * @throws AtlanException on any API problems
      */
-    public static Glossary updateCertificate(String qualifiedName, AtlanCertificateStatus certificate, String message)
+    public static Glossary updateCertificate(String qualifiedName, String name, AtlanCertificateStatus certificate, String message)
             throws AtlanException {
-        return (Glossary) Asset.updateCertificate(builder(), TYPE_NAME, qualifiedName, certificate, message);
+        return (Glossary) Asset.updateCertificate(builder().name(name), TYPE_NAME, qualifiedName, certificate, message);
     }
 
     /**
@@ -473,6 +474,7 @@ public class Glossary extends Asset {
      * Update the announcement on a Glossary.
      *
      * @param qualifiedName of the Glossary
+     * @param name of the Glossary
      * @param type type of announcement to set
      * @param title (optional) title of the announcement to set (or null for no title)
      * @param message (optional) message of the announcement to set (or null for no message)
@@ -480,8 +482,8 @@ public class Glossary extends Asset {
      * @throws AtlanException on any API problems
      */
     public static Glossary updateAnnouncement(
-            String qualifiedName, AtlanAnnouncementType type, String title, String message) throws AtlanException {
-        return (Glossary) Asset.updateAnnouncement(builder(), TYPE_NAME, qualifiedName, type, title, message);
+            String qualifiedName, String name, AtlanAnnouncementType type, String title, String message) throws AtlanException {
+        return (Glossary) Asset.updateAnnouncement(builder().name(name), TYPE_NAME, qualifiedName, type, title, message);
     }
 
     /**

--- a/src/main/java/com/atlan/model/assets/S3Object.java
+++ b/src/main/java/com/atlan/model/assets/S3Object.java
@@ -8,6 +8,7 @@ import com.atlan.exception.InvalidRequestException;
 import com.atlan.exception.NotFoundException;
 import com.atlan.model.enums.*;
 import com.atlan.model.relations.UniqueAttributes;
+import com.atlan.util.StringUtils;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.*;
@@ -98,17 +99,23 @@ public class S3Object extends S3 {
      * Builds the minimal object necessary to create an S3 object.
      *
      * @param name of the S3 object
-     * @param connectionQualifiedName unique name of the connection through which the object is accessible
+     * @param bucketQualifiedName unique name of the S3 bucket in which the object exists
+     * @param bucketName simple human-readable name of the S3 bucket in which the object exists
      * @param awsArn unique ARN of the object
      * @return the minimal object necessary to create the S3 object, as a builder
      */
-    public static S3ObjectBuilder<?, ?> creator(String name, String connectionQualifiedName, String awsArn) {
+    public static S3ObjectBuilder<?, ?> creator(
+            String name, String bucketQualifiedName, String bucketName, String awsArn) {
+        String connectionQualifiedName = StringUtils.getConnectionQualifiedName(bucketQualifiedName);
         return S3Object.builder()
                 .qualifiedName(generateQualifiedName(connectionQualifiedName, awsArn))
                 .name(name)
                 .connectionQualifiedName(connectionQualifiedName)
                 .connectorType(AtlanConnectorType.S3)
-                .awsArn(awsArn);
+                .awsArn(awsArn)
+                .s3BucketQualifiedName(bucketQualifiedName)
+                .s3BucketName(bucketName)
+                .bucket(S3Bucket.refByQualifiedName(bucketQualifiedName));
     }
 
     /**

--- a/src/main/java/com/atlan/model/enums/AtlanConnectorType.java
+++ b/src/main/java/com/atlan/model/enums/AtlanConnectorType.java
@@ -40,7 +40,14 @@ public enum AtlanConnectorType implements AtlanEnum {
     GCS("gcs", AtlanConnectionCategory.OBJECT_STORE),
     HIVE("hive", AtlanConnectionCategory.WAREHOUSE),
     SAPHANA("sap-hana", AtlanConnectionCategory.WAREHOUSE),
-    ADLS("adls", AtlanConnectionCategory.OBJECT_STORE);
+    ADLS("adls", AtlanConnectionCategory.OBJECT_STORE),
+    SIGMA("sigma", AtlanConnectionCategory.BI),
+    SYNAPSE("synapse", AtlanConnectionCategory.WAREHOUSE),
+    AIRFLOW("airflow", AtlanConnectionCategory.ELT),
+    OPENLINEAGE("openlineage", AtlanConnectionCategory.ELT),
+    DATAFLOW("dataflow", AtlanConnectionCategory.ELT),
+    QLIKSENSE("qlik-sense", AtlanConnectionCategory.BI),
+    ;
 
     @JsonValue
     @Getter(onMethod_ = {@Override})

--- a/src/main/java/com/atlan/model/typedefs/ClassificationDef.java
+++ b/src/main/java/com/atlan/model/typedefs/ClassificationDef.java
@@ -70,6 +70,7 @@ public class ClassificationDef extends TypeDef {
     public ClassificationDef create() throws AtlanException {
         TypeDefResponse response = TypeDefsEndpoint.createTypeDef(this);
         if (response != null && !response.getClassificationDefs().isEmpty()) {
+            ClassificationCache.refreshCache();
             return response.getClassificationDefs().get(0);
         }
         return null;
@@ -85,5 +86,6 @@ public class ClassificationDef extends TypeDef {
     public static void purge(String displayName) throws AtlanException {
         String internalName = ClassificationCache.getIdForName(displayName);
         TypeDefsEndpoint.purgeTypeDef(internalName);
+        ClassificationCache.refreshCache();
     }
 }

--- a/src/main/java/com/atlan/model/typedefs/CustomMetadataDef.java
+++ b/src/main/java/com/atlan/model/typedefs/CustomMetadataDef.java
@@ -53,6 +53,7 @@ public class CustomMetadataDef extends TypeDef {
     public CustomMetadataDef create() throws AtlanException {
         TypeDefResponse response = TypeDefsEndpoint.createTypeDef(this);
         if (response != null && !response.getCustomMetadataDefs().isEmpty()) {
+            CustomMetadataCache.refreshCache();
             return response.getCustomMetadataDefs().get(0);
         }
         return null;
@@ -84,5 +85,6 @@ public class CustomMetadataDef extends TypeDef {
     public static void purge(String displayName) throws AtlanException {
         String internalName = CustomMetadataCache.getIdForName(displayName);
         TypeDefsEndpoint.purgeTypeDef(internalName);
+        CustomMetadataCache.refreshCache();
     }
 }

--- a/src/main/java/com/atlan/model/workflow/WorkflowResponse.java
+++ b/src/main/java/com/atlan/model/workflow/WorkflowResponse.java
@@ -57,15 +57,18 @@ public class WorkflowResponse extends ApiResource {
                     status = runDetails.getStatus();
                 }
                 if (log != null) {
-                    log.info("Workflow status: {}", status);
+                    log.debug("Workflow status: {}", status);
                 }
             } while (status != AtlanWorkflowPhase.SUCCESS
                     && status != AtlanWorkflowPhase.ERROR
                     && status != AtlanWorkflowPhase.FAILED);
+            if (log != null) {
+                log.info("Workflow completion status: {}", status);
+            }
             return status;
         } else {
             if (log != null) {
-                log.info("... skipping workflow monitoring — nothing to monitor.");
+                log.info("Skipping workflow monitoring — nothing to monitor.");
             }
             return null;
         }

--- a/src/main/java/com/atlan/net/HttpClient.java
+++ b/src/main/java/com/atlan/net/HttpClient.java
@@ -212,13 +212,13 @@ public abstract class HttpClient {
                 && (exception.getCause() != null)
                 && (exception.getCause() instanceof ConnectException
                         || exception.getCause() instanceof SocketTimeoutException)) {
-            log.info(" ... network issue, will retry.");
+            log.debug(" ... network issue, will retry.");
             return true;
         }
 
         // Retry on permission failure (since these are granted asynchronously)
         if (response != null && response.code() == 403) {
-            log.info(" ... no permission for the operation (yet), will retry.");
+            log.debug(" ... no permission for the operation (yet), will retry.");
             return true;
         }
 

--- a/src/main/java/com/atlan/net/LiveAtlanResponseGetter.java
+++ b/src/main/java/com/atlan/net/LiveAtlanResponseGetter.java
@@ -105,13 +105,13 @@ public class LiveAtlanResponseGetter implements AtlanResponseGetter {
         AtlanException exception = null;
 
         // Check for a 500 response first -- if found, we won't have a JSON body to parse,
-        // so preemptively exit with an invalid request exception.
+        // so preemptively exit with a generic ApiException pass-through.
         int rc = response.code();
         if (rc == 500) {
-            throw new InvalidRequestException(ExceptionMessageDefinition.builder()
-                    .errorMessage(response.body())
-                    .httpErrorCode(rc)
-                    .build());
+            throw new ApiException(ErrorCode.ERROR_PASSTHROUGH,
+                null,
+                "" + rc,
+                response.body() == null ? "" : response.body());
         }
 
         try {

--- a/src/main/java/com/atlan/net/LiveAtlanResponseGetter.java
+++ b/src/main/java/com/atlan/net/LiveAtlanResponseGetter.java
@@ -108,10 +108,8 @@ public class LiveAtlanResponseGetter implements AtlanResponseGetter {
         // so preemptively exit with a generic ApiException pass-through.
         int rc = response.code();
         if (rc == 500) {
-            throw new ApiException(ErrorCode.ERROR_PASSTHROUGH,
-                null,
-                "" + rc,
-                response.body() == null ? "" : response.body());
+            throw new ApiException(
+                    ErrorCode.ERROR_PASSTHROUGH, null, "" + rc, response.body() == null ? "" : response.body());
         }
 
         try {

--- a/src/main/java/com/atlan/util/StringUtils.java
+++ b/src/main/java/com/atlan/util/StringUtils.java
@@ -17,7 +17,7 @@ import java.util.regex.Pattern;
  */
 public final class StringUtils {
     private static final Pattern whitespacePattern = Pattern.compile("\\s");
-    private static final Pattern connectionQNPrefix = Pattern.compile("(default/[a-z0-9]+/[0-9]{10})/.*");
+    private static final Pattern connectionQNPrefix = Pattern.compile("(default/[a-z0-9-]+/[0-9]{10})/.*");
 
     /**
      * Checks whether a string contains any whitespace characters or not.

--- a/src/main/java/com/atlan/util/StringUtils.java
+++ b/src/main/java/com/atlan/util/StringUtils.java
@@ -9,13 +9,15 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
  * Utilities for working with strings.
  */
 public final class StringUtils {
-    private static Pattern whitespacePattern = Pattern.compile("\\s");
+    private static final Pattern whitespacePattern = Pattern.compile("\\s");
+    private static final Pattern connectionQNPrefix = Pattern.compile("(default/[a-z0-9]+/[0-9]{10})/.*");
 
     /**
      * Checks whether a string contains any whitespace characters or not.
@@ -81,6 +83,23 @@ public final class StringUtils {
      */
     public static String decodeContent(String encoded) {
         return encoded == null ? null : URLDecoder.decode(encoded.replace("%20", "+"), StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Retrieve the connection's qualifiedName from the provided asset qualifiedName.
+     * Note that this will also return null if the qualifiedName provided is for a connection (only) already!
+     *
+     * @param qualifiedName of the asset, from which to retrieve the connection's qualifiedName
+     * @return the qualifiedName of the connection, or null if none can be determined
+     */
+    public static String getConnectionQualifiedName(String qualifiedName) {
+        if (qualifiedName != null) {
+            Matcher m = connectionQNPrefix.matcher(qualifiedName);
+            if (m.find() && m.groupCount() > 0) {
+                return m.group(1);
+            }
+        }
+        return null;
     }
 
     /**

--- a/src/test/java/com/atlan/util/StringUtilsTest.java
+++ b/src/test/java/com/atlan/util/StringUtilsTest.java
@@ -9,7 +9,8 @@ import org.testng.annotations.Test;
 
 public class StringUtilsTest {
 
-    final String qualifiedName = "default/s3/1234567890/aws:arn::somewhere/something/many/more/slashes.csv";
+    final String qualifiedName1 = "default/s3/1234567890/aws:arn::somewhere/something/many/more/slashes.csv";
+    final String qualifiedName2 = "default/sap-hana/1234567890/DATABASE/SCHEMA/table/column";
 
     @Test
     void containsWhitespace() {
@@ -41,9 +42,11 @@ public class StringUtilsTest {
     void getConnectionQualifiedName() {
         String t1 = "default/s3/1234567890";
         String invalid = "default/mongo/someName/and/then/more";
-        assertEquals(StringUtils.getConnectionQualifiedName(qualifiedName), t1);
+        assertEquals(StringUtils.getConnectionQualifiedName(qualifiedName1), t1);
         assertNull(StringUtils.getConnectionQualifiedName(invalid));
         assertNull(StringUtils.getConnectionQualifiedName(t1));
+        String t2 = "default/sap-hana/1234567890";
+        assertEquals(StringUtils.getConnectionQualifiedName(qualifiedName2), t2);
     }
 
     @Test

--- a/src/test/java/com/atlan/util/StringUtilsTest.java
+++ b/src/test/java/com/atlan/util/StringUtilsTest.java
@@ -9,6 +9,8 @@ import org.testng.annotations.Test;
 
 public class StringUtilsTest {
 
+    final String qualifiedName = "default/s3/1234567890/aws:arn::somewhere/something/many/more/slashes.csv";
+
     @Test
     void containsWhitespace() {
         assertTrue(StringUtils.containsWhitespace("this is a test"));
@@ -33,6 +35,15 @@ public class StringUtilsTest {
         String t2 = "setQualifiedName";
         assertEquals(StringUtils.getFieldNameFromMethodName(t1), "classifications");
         assertEquals(StringUtils.getFieldNameFromMethodName(t2), "qualifiedName");
+    }
+
+    @Test
+    void getConnectionQualifiedName() {
+        String t1 = "default/s3/1234567890";
+        String invalid = "default/mongo/someName/and/then/more";
+        assertEquals(StringUtils.getConnectionQualifiedName(qualifiedName), t1);
+        assertNull(StringUtils.getConnectionQualifiedName(invalid));
+        assertNull(StringUtils.getConnectionQualifiedName(t1));
     }
 
     @Test


### PR DESCRIPTION
Enhancements:

- Adds new connector types

Fixes:

- Pass-through internal server error details
- Persona and purpose are now supplied a default blank description, as required now by the API interface
- Invalidates and refreshes caches any time a type definition is created, updated, or deleted via the SDK
- Drops optional `entityGuid` when setting classification assignments
- Reduces logging level for retries from `INFO` to `DEBUG`

Breaking:

- S3 objects now require `bucketQualifiedName` and `bucketName` for creation
- Removes the `updater()` method for personas and purposes — should always retrieve first, and then update the retrieved object
- Makes `name` a mandatory parameter for `updateCertificate()` and `updateAnnouncement()` operations on a glossary