### PR TITLE
Minor fixes / enhancements

### DIFF
--- a/samples/packages/relational-assets-builder/src/main/kotlin/com/atlan/pkg/rab/ColumnImporter.kt
+++ b/samples/packages/relational-assets-builder/src/main/kotlin/com/atlan/pkg/rab/ColumnImporter.kt
@@ -48,7 +48,7 @@ class ColumnImporter(
         val qnDetails = getQualifiedNameDetails(deserializer.row, deserializer.heading, typeNameFilter)
         val connectionQN = connectionImporter.getBuilder(deserializer).build().qualifiedName
         val parentQN = "$connectionQN/${qnDetails.parentPartialQN}"
-        val parentType = preprocessed.entityQualifiedNameToType[qnDetails.parentUniqueQN]
+        val parentType = preprocessed.entityQualifiedNameToType[qnDetails.parentUniqueQN] ?: throw IllegalStateException("Could not find any table/view at: ${qnDetails.parentUniqueQN}")
         return Column.creator(name, parentType, parentQN, order)
     }
 }

--- a/sdk/src/main/java/com/atlan/util/AssetBatch.java
+++ b/sdk/src/main/java/com/atlan/util/AssetBatch.java
@@ -8,6 +8,7 @@ import com.atlan.exception.InvalidRequestException;
 import com.atlan.model.assets.Asset;
 import com.atlan.model.assets.IndistinctAsset;
 import com.atlan.model.core.AssetMutationResponse;
+import com.atlan.model.core.ConnectionCreationResponse;
 import com.atlan.serde.Serde;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -249,6 +250,9 @@ public class AssetBatch {
                         case MERGE:
                             response = client.assets.saveMergingCM(revised, replaceAtlanTags);
                             break;
+                    }
+                    if (response instanceof ConnectionCreationResponse) {
+                        response = ((ConnectionCreationResponse) response).block();
                     }
                 } catch (AtlanException e) {
                     if (captureFailures) {


### PR DESCRIPTION
- Adds a blocking call on connection creation to asset batching
- Adds more meaningful error message to relational assets builder if a column refers to a non-existent parent