### PR TITLE
Enhancements and fixes

### DIFF
--- a/sdk/src/main/java/com/atlan/AtlanClient.java
+++ b/sdk/src/main/java/com/atlan/AtlanClient.java
@@ -118,6 +118,9 @@ public class AtlanClient {
     /** Endpoint with operations to manage query parsing. */
     public final QueryParserEndpoint queryParser;
 
+    /** Endpoint with operations to run SQL queries. */
+    public final QueriesEndpoint queries;
+
     /** Endpoint with operations to manage playbooks. */
     public final PlaybooksEndpoint playbooks;
 
@@ -183,6 +186,7 @@ public class AtlanClient {
         users = new UsersEndpoint(this);
         workflows = new WorkflowsEndpoint(this);
         queryParser = new QueryParserEndpoint(this);
+        queries = new QueriesEndpoint(this);
         playbooks = new PlaybooksEndpoint(this);
         logs = new LogsEndpoint(this);
         images = new ImagesEndpoint(this);

--- a/sdk/src/main/java/com/atlan/AtlanClient.java
+++ b/sdk/src/main/java/com/atlan/AtlanClient.java
@@ -195,9 +195,9 @@ public class AtlanClient {
         atlanTagCache = new AtlanTagCache(typeDefs);
         customMetadataCache = new CustomMetadataCache(typeDefs);
         enumCache = new EnumCache(typeDefs);
-        groupCache = new GroupCache();
+        groupCache = new GroupCache(groups);
         roleCache = new RoleCache(roles);
-        userCache = new UserCache();
+        userCache = new UserCache(users, apiTokens);
         assetDeserializer = new AssetDeserializer(this);
         customMetadataAuditDeserializer = new CustomMetadataAuditDeserializer(this);
         atlanTagDeserializer = new AtlanTagDeserializer(this);

--- a/sdk/src/main/java/com/atlan/api/ApiTokensEndpoint.java
+++ b/sdk/src/main/java/com/atlan/api/ApiTokensEndpoint.java
@@ -121,8 +121,8 @@ public class ApiTokensEndpoint extends HeraclesEndpoint {
      * @throws AtlanException on any error during API invocation
      */
     public ApiToken getById(String clientId) throws AtlanException {
-        if (clientId != null && clientId.startsWith("service-account-")) {
-            clientId = clientId.substring("service-account-".length());
+        if (clientId != null && clientId.startsWith(ApiToken.API_USERNAME_PREFIX)) {
+            clientId = clientId.substring(ApiToken.API_USERNAME_PREFIX.length());
         }
         ApiTokenResponse response = list("{\"clientId\":\"" + clientId + "\"}", "-createdAt", 0, 2);
         if (response != null

--- a/sdk/src/main/java/com/atlan/api/QueriesEndpoint.java
+++ b/sdk/src/main/java/com/atlan/api/QueriesEndpoint.java
@@ -1,0 +1,48 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.api;
+
+import com.atlan.AtlanClient;
+import com.atlan.exception.AtlanException;
+import com.atlan.model.admin.QueryRequest;
+import com.atlan.model.admin.QueryResponse;
+import com.atlan.net.ApiEventStreamResource;
+import com.atlan.net.ApiResource;
+import com.atlan.net.RequestOptions;
+
+/**
+ * API endpoints for running SQL queries.
+ */
+public class QueriesEndpoint extends HekaEndpoint {
+
+    private static final String endpoint = "/query/stream";
+
+    public QueriesEndpoint(AtlanClient client) {
+        super(client);
+    }
+
+    /**
+     * Runs the provided query and returns its results.
+     *
+     * @param request query to run
+     * @return results of the query
+     * @throws AtlanException on any issues with API communication
+     */
+    public QueryResponse stream(QueryRequest request) throws AtlanException {
+        return stream(request, null);
+    }
+
+    /**
+     * Runs the provided query and returns its results.
+     *
+     * @param request query to run
+     * @param options to override default client settings
+     * @return results of the query
+     * @throws AtlanException on any issues with API communication
+     */
+    public QueryResponse stream(QueryRequest request, RequestOptions options) throws AtlanException {
+        String url = String.format("%s%s", getBaseUrl(), endpoint);
+        return ApiEventStreamResource.request(
+                client, ApiResource.RequestMethod.POST, url, request, QueryResponse.class, options);
+    }
+}

--- a/sdk/src/main/java/com/atlan/cache/GroupCache.java
+++ b/sdk/src/main/java/com/atlan/cache/GroupCache.java
@@ -2,6 +2,7 @@
    Copyright 2022 Atlan Pte. Ltd. */
 package com.atlan.cache;
 
+import com.atlan.api.GroupsEndpoint;
 import com.atlan.exception.AtlanException;
 import com.atlan.exception.ErrorCode;
 import com.atlan.exception.InvalidRequestException;
@@ -21,9 +22,15 @@ public class GroupCache {
     private Map<String, String> mapNameToId = new ConcurrentHashMap<>();
     private Map<String, String> mapAliasToId = new ConcurrentHashMap<>();
 
+    private final GroupsEndpoint groupsEndpoint;
+
+    public GroupCache(GroupsEndpoint groupsEndpoint) {
+        this.groupsEndpoint = groupsEndpoint;
+    }
+
     private synchronized void refreshCache() throws AtlanException {
         log.debug("Refreshing cache of groups...");
-        List<AtlanGroup> groups = AtlanGroup.list();
+        List<AtlanGroup> groups = groupsEndpoint.list();
         mapIdToName = new ConcurrentHashMap<>();
         mapNameToId = new ConcurrentHashMap<>();
         mapAliasToId = new ConcurrentHashMap<>();

--- a/sdk/src/main/java/com/atlan/exception/ErrorCode.java
+++ b/sdk/src/main/java/com/atlan/exception/ErrorCode.java
@@ -429,6 +429,11 @@ public enum ErrorCode implements ExceptionMessageSet {
             "ATLAN-JAVA-404-026",
             "Unable to find a query with the name: {0}.",
             "Verify the requested query exists in your Atlan environment."),
+    API_TOKEN_NOT_FOUND_BY_NAME(
+            404,
+            "ATLAN-JAVA-404-027",
+            "API token with name {0} does not exist.",
+            "Verify the API token provided is a valid username for that token."),
 
     CONFLICT_PASSTHROUGH(
             409,

--- a/sdk/src/main/java/com/atlan/exception/ErrorCode.java
+++ b/sdk/src/main/java/com/atlan/exception/ErrorCode.java
@@ -463,7 +463,7 @@ public enum ErrorCode implements ExceptionMessageSet {
             "ATLAN-JAVA-500-001",
             "Multiple custom attributes with exactly the same name ({0}) were found for: {1}.",
             ErrorCode.RAISE_GITHUB_ISSUE),
-    UNABLE_TO_DESERIALIZE(500, "ATLAN-JAVA-500-002", "Unable to deserialize value: [0]", ErrorCode.RAISE_GITHUB_ISSUE),
+    UNABLE_TO_DESERIALIZE(500, "ATLAN-JAVA-500-002", "Unable to deserialize value: {0}", ErrorCode.RAISE_GITHUB_ISSUE),
     UNABLE_TO_PARSE_ORIGINAL_QUERY(
             500,
             "ATLAN-JAVA-500-003",

--- a/sdk/src/main/java/com/atlan/model/admin/ApiToken.java
+++ b/sdk/src/main/java/com/atlan/model/admin/ApiToken.java
@@ -38,6 +38,7 @@ import lombok.extern.jackson.Jacksonized;
 public class ApiToken extends AtlanObject {
 
     private static final long serialVersionUID = 2L;
+    public static final String API_USERNAME_PREFIX = "service-account-";
 
     /** Unique identifier (GUID) of the API token. */
     @Getter
@@ -69,6 +70,18 @@ public class ApiToken extends AtlanObject {
             return attributes.getDisplayName();
         }
         return null;
+    }
+
+    /**
+     * Retrieve the username that represents this API token.
+     * This name can be used to assign the token as a user to objects that require a user,
+     * such as policies.
+     *
+     * @return a username for this API token
+     */
+    @JsonIgnore
+    public String getApiTokenUsername() {
+        return API_USERNAME_PREFIX + getClientId();
     }
 
     /**

--- a/sdk/src/main/java/com/atlan/model/admin/ApiToken.java
+++ b/sdk/src/main/java/com/atlan/model/admin/ApiToken.java
@@ -257,8 +257,14 @@ public class ApiToken extends AtlanObject {
         @Singular
         SortedSet<ApiTokenPersona> personas;
 
-        /** Possible future placeholder for purposes association with the token. */
+        /**
+         * This was a possible future placeholder for purposes associated with the token,
+         * but no longer exists on payloads. It is left here purely for any existing code
+         * that may have referenced it, but should be removed from that code as it will be
+         * removed in the next major release from this object.
+         */
         @JsonIgnore
+        @Deprecated
         String purposes;
 
         /** Detailed permissions given to the API token. */

--- a/sdk/src/main/java/com/atlan/model/admin/QueryRequest.java
+++ b/sdk/src/main/java/com/atlan/model/admin/QueryRequest.java
@@ -1,0 +1,37 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2023 Atlan Pte. Ltd. */
+package com.atlan.model.admin;
+
+import com.atlan.model.core.AtlanObject;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public class QueryRequest extends AtlanObject {
+    private static final long serialVersionUID = 2L;
+
+    /** SQL query to run. */
+    String sql;
+
+    /** Unique name of the connection to use for the query. */
+    String dataSourceName;
+
+    /** Default schema name to use for unqualified objects in the SQL, in the form {@code DB.SCHEMA}. */
+    String defaultSchema;
+
+    /**
+     * Builds the minimal object necessary to run a query.
+     *
+     * @param sql the SQL code to parse
+     * @param connectionQualifiedName qualifiedName of the connection on which to run the query
+     * @return the minimal request necessary to run a query, as a builder
+     */
+    public static QueryRequestBuilder<?, ?> creator(String sql, String connectionQualifiedName) {
+        return QueryRequest.builder().sql(sql).dataSourceName(connectionQualifiedName);
+    }
+}

--- a/sdk/src/main/java/com/atlan/model/admin/QueryResponse.java
+++ b/sdk/src/main/java/com/atlan/model/admin/QueryResponse.java
@@ -3,6 +3,9 @@
 package com.atlan.model.admin;
 
 import com.atlan.model.core.AtlanObject;
+import com.atlan.model.enums.HekaFlow;
+import com.atlan.model.enums.ParsingFlow;
+import com.atlan.model.enums.QueryStatus;
 import com.atlan.net.ApiEventStreamResource;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -130,13 +133,25 @@ public class QueryResponse extends ApiEventStreamResource {
         /** Position of the column (1-based). */
         Integer ordinal;
 
+        /** TBC */
         Boolean autoIncrement;
 
+        /** TBC */
         Boolean caseSensitive;
+
+        /** TBC */
         Boolean searchable;
+
+        /** TBC */
         Boolean currency;
+
+        /** TBC */
         Integer nullable;
+
+        /** TBC */
         Boolean signed;
+
+        /** TBC */
         Integer displaySize;
 
         /** Display value for the column's name. */
@@ -148,8 +163,10 @@ public class QueryResponse extends ApiEventStreamResource {
         /** Name of the schema in which this column's table is contained. */
         String schemaName;
 
+        /** TBC */
         Integer precision;
 
+        /** TBC */
         Integer scale;
 
         /** Name of the table in which the column is contained. */
@@ -158,8 +175,13 @@ public class QueryResponse extends ApiEventStreamResource {
         /** Name of the database in which the table's schema is contained. */
         String catalogName;
 
+        /** TBC */
         Boolean readOnly;
+
+        /** TBC */
         Boolean writable;
+
+        /** TBC */
         Boolean definitelyWritable;
 
         /** Canonical name of the Java class representing this column's values. */
@@ -201,8 +223,7 @@ public class QueryResponse extends ApiEventStreamResource {
         Long totalRowsStreamed;
 
         /** Status of the query. */
-        String status; // TODO: enum -- started, in-progress, completed, error <-- different structure to the rest in
-        // this case
+        QueryStatus status;
 
         /** TBC */
         String parsedQuery;
@@ -213,55 +234,142 @@ public class QueryResponse extends ApiEventStreamResource {
         /** How long the query took to run, in milliseconds. */
         Long executionTime;
 
+        /** TBC */
         String sourceQueryId;
 
+        /** TBC */
         String resultOutputLocation;
 
-        List<Object> warnings;
+        /** List of any warnings produced when running the query. */
+        List<String> warnings;
 
-        String parsingFlow;
+        /** How the query was parsed prior to running. */
+        ParsingFlow parsingFlow;
 
-        String hekaFlow;
+        /** How the query was run. */
+        HekaFlow hekaFlow;
 
+        /** TBC */
         String s3UploadPath;
 
-        @JsonProperty("source_first_connection_time_perc")
-        Double sourceFirstConnectionTimePercentage;
+        /** TBC */
+        @JsonProperty("source_first_connection_time")
+        Integer sourceFirstConnectionTime;
 
+        /** TBC */
+        @JsonProperty("source_first_connection_time_perc")
+        Double sourceFirstConnectionPercentage;
+
+        /** TBC */
         @JsonProperty("explain_call_time_perc")
         Double explainCallTimePercentage;
 
-        // TODO: include remaining properties
-        /*
-            More...
-            "init_data_source_time_perc": 0.0,
-        "authorization_time_perc": 0.0,
-        "rewrite_validation_time_perc": 0.001,
-        "extract_table_metadata_time": 32,
-        "execution_time": 370,
-        "bypass_parsing_time": 3,
-        "check_insights_enabled_time": 0,
-        "initialization_time_perc": 0.0,
-        "rewrite_validation_time": 2,
-        "init_data_source_time": 0,
-        "extract_credentials_time_perc": 0.0,
-        "overall_time_perc": 1.0,
-        "heka_atlan_time": 1847,
-        "bypass_parsing_time_perc": 0.001,
-        "extract_credentials_time": 0,
-        "extract_table_metadata_time_perc": 0.014,
-        "initialization_time": 1,
-        "calcite_parsing_time_perc": 0,
-        "overall_time": 2217,
-        "calcite_validation_time_perc": 0,
-        "execution_time_perc": 0.167,
-        "source_first_connection_time": 1633,
-        "authorization_time": 0,
-        "check_insights_enabled_time_perc": 0.0
-             */
+        /** TBC */
+        @JsonProperty("init_data_source_time")
+        Integer initDataSourceTime;
+
+        /** TBC */
+        @JsonProperty("init_data_source_time_perc")
+        Double initDataSourcePercentage;
+
+        /** TBC */
+        @JsonProperty("authorization_time")
+        Integer authorizationTime;
+
+        /** TBC */
+        @JsonProperty("authorization_time_perc")
+        Double authorizationPercentage;
+
+        /** TBC */
+        @JsonProperty("rewrite_validation_time")
+        Integer rewriteValidationTime;
+
+        /** TBC */
+        @JsonProperty("rewrite_validation_time_perc")
+        Double rewriteValidationPercentage;
+
+        /** Elapsed time to extract table metadata, in milliseconds. */
+        @JsonProperty("extract_table_metadata_time")
+        Integer extractTableMetadataTime;
+
+        /** TBC */
+        @JsonProperty("extract_table_metadata_time_perc")
+        Double extractTableMetadataPercentage;
+
+        /** Elapsed time to run the query (from internal engine), in milliseconds. */
+        @JsonProperty("execution_time")
+        Integer executionTimeInternal;
+
+        /** TBC */
+        @JsonProperty("execution_time_perc")
+        Double executionPercentage;
+
+        /** TBC */
+        @JsonProperty("bypass_parsing_time")
+        Integer bypassQueryTime;
+
+        /** TBC */
+        @JsonProperty("bypass_parsing_time_perc")
+        Double bypassParsingPercentage;
+
+        /** TBC */
+        @JsonProperty("check_insights_enabled_time")
+        Integer checkInsightsEnabledTime;
+
+        /** TBC */
+        @JsonProperty("check_insights_enabled_time_perc")
+        Double checkInsightsEnabledPercentage;
+
+        /** TBC */
+        @JsonProperty("initialization_time")
+        Integer initializationTime;
+
+        /** TBC */
+        @JsonProperty("initialization_time_perc")
+        Double initializationPercentage;
+
+        /** TBC */
+        @JsonProperty("extract_credentials_time")
+        Integer extractCredentialsTime;
+
+        /** TBC */
+        @JsonProperty("extract_credentials_time_perc")
+        Double extractCredentialsPercentage;
+
+        /** TBC */
+        @JsonProperty("overall_time")
+        Integer overallTime;
+
+        /** TBC */
+        @JsonProperty("overall_time_perc")
+        Double overallTimePercentage;
+
+        /** TBC */
+        @JsonProperty("heka_atlan_time")
+        Integer hekaAtlanTime;
+
+        /** TBC */
+        @JsonProperty("calcite_parsing_time_perc")
+        Double calciteParsingPercentage;
+
+        /** TBC */
+        @JsonProperty("calcite_validation_time_perc")
+        Double calciteValidationPercentage;
+
+        /** Metadata about the asset used in the query, in case of any errors. */
+        AssetDetails asset;
 
         /** Detailed back-end error message that could be helpful for developers. */
         String developerMessage;
+
+        /** Line number of the query that had a validation error, if any. */
+        Long line;
+
+        /** Column position of the validation error, if any. */
+        Long column;
+
+        /** Name of the object that caused the validation error, if any. */
+        String object;
     }
 
     /** Details about an asset that was queried, in case of errors. */
@@ -286,6 +394,6 @@ public class QueryResponse extends ApiEventStreamResource {
         String schema;
 
         /** Simple name of the table. */
-        String table; // TODO: what about views?
+        String table;
     }
 }

--- a/sdk/src/main/java/com/atlan/model/admin/QueryResponse.java
+++ b/sdk/src/main/java/com/atlan/model/admin/QueryResponse.java
@@ -1,0 +1,291 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.admin;
+
+import com.atlan.model.core.AtlanObject;
+import com.atlan.net.ApiEventStreamResource;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Response containing the details of a parsed SQL query.
+ */
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@ToString(callSuper = true)
+public class QueryResponse extends ApiEventStreamResource {
+    private static final long serialVersionUID = 2L;
+
+    /**
+     * Create a single consolidated response from multiple events related to the same query.
+     * (All ApiEventStreamResource objects must have a List constructor like this, as it is
+     * used as part of the response deserialization process, via reflection.)
+     *
+     * @param events detailing the streamed results of a query
+     */
+    public QueryResponse(List<QueryResponse> events) {
+        if (events != null) {
+            rows = new ArrayList<>();
+            columns = new ArrayList<>();
+            // Populate the results from all events that have rows
+            for (QueryResponse event : events) {
+                if (event.getRows() != null && !event.getRows().isEmpty()) {
+                    rows.addAll(event.getRows());
+                }
+                if (columns.isEmpty()
+                        && event.getColumns() != null
+                        && !event.getColumns().isEmpty()) {
+                    // Only need to do this once
+                    columns = event.getColumns();
+                }
+            }
+            // Populate the remainder from the final event
+            QueryResponse lastEvent = events.get(events.size() - 1);
+            requestId = lastEvent.getRequestId();
+            errorName = lastEvent.getErrorName();
+            errorMessage = lastEvent.getErrorMessage();
+            errorCode = lastEvent.getErrorCode();
+            queryId = lastEvent.getQueryId();
+            details = lastEvent.getDetails();
+        }
+    }
+
+    /**
+     * All-args constructor needed by Jackson to deserialize individual events.
+     * (Used by Jackson as part of the response deserialization process.)
+     *
+     * @param requestId see {@link #requestId}
+     * @param errorName see {@link #errorName}
+     * @param errorMessage see {@link #errorMessage}
+     * @param errorCode see {@link #errorCode}
+     * @param queryId see {@link #queryId}
+     * @param rows see {@link #rows}
+     * @param columns see {@link #columns}
+     * @param details see {@link #details}
+     */
+    @JsonCreator
+    public QueryResponse(
+            @JsonProperty("requestId") String requestId,
+            @JsonProperty("errorName") String errorName,
+            @JsonProperty("errorMessage") String errorMessage,
+            @JsonProperty("errorCode") String errorCode,
+            @JsonProperty("queryId") String queryId,
+            @JsonProperty("rows") List<List<String>> rows,
+            @JsonProperty("columns") List<ColumnDetails> columns,
+            @JsonProperty("details") QueryDetails details) {
+        this.requestId = requestId;
+        this.errorName = errorName;
+        this.errorMessage = errorMessage;
+        this.errorCode = errorCode;
+        this.queryId = queryId;
+        this.rows = rows;
+        this.columns = columns;
+        this.details = details;
+    }
+
+    /** Unique identifier for the request, if there was any error. */
+    String requestId;
+
+    /** Unique name for the error, if there was any error. */
+    String errorName;
+
+    /** Explanation of the error, if there was any error. */
+    String errorMessage;
+
+    /** Unique code for the error, if there was any error. */
+    String errorCode;
+
+    /** Unique identifier (GUID) for the specific run of the query. */
+    String queryId;
+
+    /**
+     * Results of the query. Each element is of the outer list is a single row,
+     * while each inner list gives the column values for that row (in order).
+     */
+    List<List<String>> rows;
+
+    /**
+     * Columns that are present in each row of the results. The order of the elements
+     * of this list will match the order of the inner list of values for the {@link #rows}.
+     */
+    List<ColumnDetails> columns;
+
+    /** Details about the query. */
+    QueryDetails details;
+
+    /** Details about the columns that were returned from a query that was run. */
+    @Getter
+    @Jacksonized
+    @SuperBuilder(toBuilder = true)
+    @EqualsAndHashCode(callSuper = true)
+    @ToString(callSuper = true)
+    public static final class ColumnDetails extends AtlanObject {
+        private static final long serialVersionUID = 2L;
+
+        /** Position of the column (1-based). */
+        Integer ordinal;
+
+        Boolean autoIncrement;
+
+        Boolean caseSensitive;
+        Boolean searchable;
+        Boolean currency;
+        Integer nullable;
+        Boolean signed;
+        Integer displaySize;
+
+        /** Display value for the column's name. */
+        String label;
+
+        /** Name of the column (technical). */
+        String columnName;
+
+        /** Name of the schema in which this column's table is contained. */
+        String schemaName;
+
+        Integer precision;
+
+        Integer scale;
+
+        /** Name of the table in which the column is contained. */
+        String tableName;
+
+        /** Name of the database in which the table's schema is contained. */
+        String catalogName;
+
+        Boolean readOnly;
+        Boolean writable;
+        Boolean definitelyWritable;
+
+        /** Canonical name of the Java class representing this column's values. */
+        String columnClassName;
+
+        /** Details about the (SQL) data type of the column. */
+        ColumnType type;
+    }
+
+    /** Details about the type of column that was returned from a query that was run. */
+    @Getter
+    @Jacksonized
+    @SuperBuilder(toBuilder = true)
+    @EqualsAndHashCode(callSuper = true)
+    @ToString(callSuper = true)
+    public static final class ColumnType extends AtlanObject {
+        private static final long serialVersionUID = 2L;
+
+        /** Numeric identifier for this column, generally matches the ordinal of the column. */
+        Integer id;
+
+        /** SQL name of the data type for this column. */
+        String name;
+
+        /** TBC */
+        String rep;
+    }
+
+    /** Details about a query that was run. */
+    @Getter
+    @Jacksonized
+    @SuperBuilder(toBuilder = true)
+    @EqualsAndHashCode(callSuper = true)
+    @ToString(callSuper = true)
+    public static final class QueryDetails extends AtlanObject {
+        private static final long serialVersionUID = 2L;
+
+        /** Total number of results returned by the query. */
+        Long totalRowsStreamed;
+
+        /** Status of the query. */
+        String status; // TODO: enum -- started, in-progress, completed, error <-- different structure to the rest in
+        // this case
+
+        /** TBC */
+        String parsedQuery;
+
+        /** Query that was sent to the data store. */
+        String pushdownQuery;
+
+        /** How long the query took to run, in milliseconds. */
+        Long executionTime;
+
+        String sourceQueryId;
+
+        String resultOutputLocation;
+
+        List<Object> warnings;
+
+        String parsingFlow;
+
+        String hekaFlow;
+
+        String s3UploadPath;
+
+        @JsonProperty("source_first_connection_time_perc")
+        Double sourceFirstConnectionTimePercentage;
+
+        @JsonProperty("explain_call_time_perc")
+        Double explainCallTimePercentage;
+
+        // TODO: include remaining properties
+        /*
+            More...
+            "init_data_source_time_perc": 0.0,
+        "authorization_time_perc": 0.0,
+        "rewrite_validation_time_perc": 0.001,
+        "extract_table_metadata_time": 32,
+        "execution_time": 370,
+        "bypass_parsing_time": 3,
+        "check_insights_enabled_time": 0,
+        "initialization_time_perc": 0.0,
+        "rewrite_validation_time": 2,
+        "init_data_source_time": 0,
+        "extract_credentials_time_perc": 0.0,
+        "overall_time_perc": 1.0,
+        "heka_atlan_time": 1847,
+        "bypass_parsing_time_perc": 0.001,
+        "extract_credentials_time": 0,
+        "extract_table_metadata_time_perc": 0.014,
+        "initialization_time": 1,
+        "calcite_parsing_time_perc": 0,
+        "overall_time": 2217,
+        "calcite_validation_time_perc": 0,
+        "execution_time_perc": 0.167,
+        "source_first_connection_time": 1633,
+        "authorization_time": 0,
+        "check_insights_enabled_time_perc": 0.0
+             */
+
+        /** Detailed back-end error message that could be helpful for developers. */
+        String developerMessage;
+    }
+
+    /** Details about an asset that was queried, in case of errors. */
+    @Getter
+    @Jacksonized
+    @SuperBuilder(toBuilder = true)
+    @EqualsAndHashCode(callSuper = true)
+    @ToString(callSuper = true)
+    public static final class AssetDetails extends AtlanObject {
+        private static final long serialVersionUID = 2L;
+
+        /** Simple name of the connection. */
+        String connectionName;
+
+        /** Unique name of the connection. */
+        String connectionQN;
+
+        /** Simple name of the database. */
+        String database;
+
+        /** Simple name of the schema. */
+        String schema;
+
+        /** Simple name of the table. */
+        String table; // TODO: what about views?
+    }
+}

--- a/sdk/src/main/java/com/atlan/model/assets/Connection.java
+++ b/sdk/src/main/java/com/atlan/model/assets/Connection.java
@@ -8,7 +8,6 @@ import com.atlan.exception.AtlanException;
 import com.atlan.exception.ErrorCode;
 import com.atlan.exception.InvalidRequestException;
 import com.atlan.exception.NotFoundException;
-import com.atlan.model.admin.ApiToken;
 import com.atlan.model.core.AssetFilter;
 import com.atlan.model.core.AssetMutationResponse;
 import com.atlan.model.core.ConnectionCreationResponse;
@@ -569,16 +568,7 @@ public class Connection extends Asset implements IConnection, IAsset, IReference
         }
         if (adminUsers != null && !adminUsers.isEmpty()) {
             for (String userName : adminUsers) {
-                try {
-                    client.getUserCache().getIdForName(userName);
-                } catch (NotFoundException e) {
-                    // If we cannot find the username, fallback to looking for an API token
-                    ApiToken token = client.apiTokens.getById(userName);
-                    if (token == null) {
-                        // If that also turns up no results, re-throw the NotFoundException
-                        throw e;
-                    }
-                }
+                client.getUserCache().getIdForName(userName);
             }
             adminFound = true;
             builder.adminUsers(adminUsers);
@@ -648,16 +638,7 @@ public class Connection extends Asset implements IConnection, IAsset, IReference
         }
         if (adminUsers != null && !adminUsers.isEmpty()) {
             for (String userName : adminUsers) {
-                try {
-                    client.getUserCache().getIdForName(userName);
-                } catch (NotFoundException e) {
-                    // If we cannot find the username, fallback to looking for an API token
-                    ApiToken token = client.apiTokens.getById(userName);
-                    if (token == null) {
-                        // If that also turns up no results, re-throw the NotFoundException
-                        throw e;
-                    }
-                }
+                client.getUserCache().getIdForName(userName);
             }
         }
         return client.assets.save(this, false);
@@ -722,16 +703,7 @@ public class Connection extends Asset implements IConnection, IAsset, IReference
         }
         if (adminUsers != null && !adminUsers.isEmpty()) {
             for (String userName : adminUsers) {
-                try {
-                    client.getUserCache().getIdForName(userName);
-                } catch (NotFoundException e) {
-                    // If we cannot find the username, fallback to looking for an API token
-                    ApiToken token = client.apiTokens.getById(userName);
-                    if (token == null) {
-                        // If that also turns up no results, re-throw the NotFoundException
-                        throw e;
-                    }
-                }
+                client.getUserCache().getIdForName(userName);
             }
         }
         return client.assets.save(this, replaceAtlanTags);

--- a/sdk/src/main/java/com/atlan/model/core/AtlanEventStreamResponseInterface.java
+++ b/sdk/src/main/java/com/atlan/model/core/AtlanEventStreamResponseInterface.java
@@ -1,0 +1,11 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.core;
+
+import com.atlan.net.AtlanEventStreamResponse;
+
+public interface AtlanEventStreamResponseInterface {
+    AtlanEventStreamResponse getLastResponse();
+
+    void setLastResponse(AtlanEventStreamResponse response);
+}

--- a/sdk/src/main/java/com/atlan/model/enums/HekaFlow.java
+++ b/sdk/src/main/java/com/atlan/model/enums/HekaFlow.java
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+public enum HekaFlow implements AtlanEnum {
+    BYPASS("BYPASS_FLOW"),
+    REWRITE("REWRITE_FLOW"),
+    PASSTHROUGH("PASSTHROUGH_FLOW"),
+    ;
+
+    @JsonValue
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    HekaFlow(String value) {
+        this.value = value;
+    }
+
+    public static HekaFlow fromValue(String value) {
+        for (HekaFlow b : HekaFlow.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}

--- a/sdk/src/main/java/com/atlan/model/enums/ParsingFlow.java
+++ b/sdk/src/main/java/com/atlan/model/enums/ParsingFlow.java
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+public enum ParsingFlow implements AtlanEnum {
+    GUDUSOFT("GUDUSOFT_FLOW"),
+    EXPLAIN_CALL("EXPLAIN_CALL_FLOW"),
+    CALCITE("CALCITE_FLOW"),
+    JSQL("JSQL_FLOW"),
+    NONE("NO_PARSING"),
+    ;
+
+    @JsonValue
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    ParsingFlow(String value) {
+        this.value = value;
+    }
+
+    public static ParsingFlow fromValue(String value) {
+        for (ParsingFlow b : ParsingFlow.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}

--- a/sdk/src/main/java/com/atlan/model/enums/QueryStatus.java
+++ b/sdk/src/main/java/com/atlan/model/enums/QueryStatus.java
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.model.enums;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+public enum QueryStatus implements AtlanEnum {
+    /** Query run has been requested, but not yet started or completed. */
+    STARTED("started"),
+
+    /** Query run is in progress (running). */
+    IN_PROGRESS("in-progress"),
+
+    /** Query has completed running, successfully. */
+    COMPLETED("completed"),
+
+    /**
+     * Some other operation on the query has completed, successfully.
+     * For example: it has been aborted or was only testing a connection.
+     */
+    OK("ok"),
+
+    /** There was an error running the query. */
+    ERROR("error"),
+    ;
+
+    @JsonValue
+    @Getter(onMethod_ = {@Override})
+    private final String value;
+
+    QueryStatus(String value) {
+        this.value = value;
+    }
+
+    public static QueryStatus fromValue(String value) {
+        for (QueryStatus b : QueryStatus.values()) {
+            if (b.value.equals(value)) {
+                return b;
+            }
+        }
+        return null;
+    }
+}

--- a/sdk/src/main/java/com/atlan/net/ApiEventStreamResource.java
+++ b/sdk/src/main/java/com/atlan/net/ApiEventStreamResource.java
@@ -1,0 +1,105 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.net;
+
+/* Based on original code from https://github.com/stripe/stripe-java (under MIT license) */
+import com.atlan.AtlanClient;
+import com.atlan.exception.AtlanException;
+import com.atlan.model.core.AtlanEventStreamResponseInterface;
+import com.atlan.model.core.AtlanObject;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.util.*;
+import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+import org.slf4j.MDC;
+
+/**
+ * Base class for all event-stream response objects.
+ */
+@Slf4j
+@ToString(callSuper = true)
+public abstract class ApiEventStreamResource extends AtlanObject implements AtlanEventStreamResponseInterface {
+    private static final long serialVersionUID = 2L;
+
+    @JsonIgnore
+    private transient AtlanEventStreamResponse lastResponse;
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @JsonIgnore
+    public AtlanEventStreamResponse getLastResponse() {
+        return lastResponse;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    @JsonIgnore
+    public void setLastResponse(AtlanEventStreamResponse response) {
+        this.lastResponse = response;
+    }
+
+    /**
+     * Pass-through to the request-handling method after confirming that the provided payload is non-null.
+     *
+     * @param client connectivity to Atlan
+     * @param method for the request
+     * @param url of the request
+     * @param payload to send in the request
+     * @param clazz defining the expected response type
+     * @param options for sending the request (or null to use global defaults)
+     * @return the response
+     * @param <T> the type of the response
+     * @throws AtlanException on any API interaction problem
+     */
+    public static <T extends ApiEventStreamResource> T request(
+            AtlanClient client,
+            ApiResource.RequestMethod method,
+            String url,
+            AtlanObject payload,
+            Class<T> clazz,
+            RequestOptions options)
+            throws AtlanException {
+        ApiResource.checkNullTypedParams(url, payload);
+        return request(client, method, url, payload.toJson(client), clazz, options);
+    }
+
+    /**
+     * Pass-through the request to the request-handling method.
+     * This method wraps debug-level logging lines around the request to show precisely what was constructed and sent
+     * to Atlan. What was returned in the response is explicitly not logged to avoid any sensitive information
+     * possibly being logged.
+     *
+     * @param client connectivity to Atlan
+     * @param method for the request
+     * @param url of the request
+     * @param body to send in the request, if any (to not send any use an empty string)
+     * @param clazz defining the expected response type
+     * @param options for sending the request (or null to use global defaults)
+     * @return the response
+     * @param <T> the type of the response
+     * @throws AtlanException on any API interaction problem
+     */
+    public static <T extends ApiEventStreamResource> T request(
+            AtlanClient client,
+            ApiResource.RequestMethod method,
+            String url,
+            String body,
+            Class<T> clazz,
+            RequestOptions options)
+            throws AtlanException {
+        // Create a unique ID for every request, and add it to the logging context and header
+        String requestId = UUID.randomUUID().toString();
+        MDC.put("X-Atlan-Request-Id", requestId);
+        log.debug("({}) {} with: {}", method, url, body);
+        T response =
+                ApiResource.atlanResponseGetter.requestStream(client, method, url, body, clazz, options, requestId);
+        // Ensure we reset the Atlan request ID, so we always have the context from the original
+        // request that was made (even if it in turn triggered off other requests)
+        MDC.put("X-Atlan-Request-Id", requestId);
+        return response;
+    }
+}

--- a/sdk/src/main/java/com/atlan/net/ApiResource.java
+++ b/sdk/src/main/java/com/atlan/net/ApiResource.java
@@ -35,7 +35,7 @@ public abstract class ApiResource extends AtlanObject implements AtlanResponseIn
 
     public static final Charset CHARSET = StandardCharsets.UTF_8;
 
-    private static final AtlanResponseGetter atlanResponseGetter = new LiveAtlanResponseGetter();
+    static final AtlanResponseGetter atlanResponseGetter = new LiveAtlanResponseGetter();
 
     @JsonIgnore
     private transient AtlanResponse lastResponse;

--- a/sdk/src/main/java/com/atlan/net/AtlanEventStreamResponse.java
+++ b/sdk/src/main/java/com/atlan/net/AtlanEventStreamResponse.java
@@ -1,0 +1,23 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2022 Atlan Pte. Ltd. */
+package com.atlan.net;
+
+import java.util.List;
+
+/**
+ * A response from Atlan's API, with body represented as a list of Strings
+ * (one element in the list per event emitted from the event stream).
+ */
+public class AtlanEventStreamResponse extends AbstractAtlanResponse<List<String>> {
+    /**
+     * Initializes a new instance of the {@link AtlanEventStreamResponse} class.
+     *
+     * @param code the HTTP status code of the response
+     * @param headers the HTTP headers of the response
+     * @param events the events emitted in the response
+     * @throws NullPointerException if {@code headers} or {@code events} is {@code null}
+     */
+    public AtlanEventStreamResponse(int code, HttpHeaders headers, List<String> events) {
+        super(code, headers, events);
+    }
+}

--- a/sdk/src/main/java/com/atlan/net/AtlanRequest.java
+++ b/sdk/src/main/java/com/atlan/net/AtlanRequest.java
@@ -75,6 +75,30 @@ public class AtlanRequest {
             RequestOptions options,
             String requestId)
             throws AtlanException {
+        this(client, method, url, body, options, requestId, "application/json");
+    }
+
+    /**
+     * Initializes a new instance of the {@link AtlanRequest} class, used for the majority of requests.
+     *
+     * @param client connectivity to an Atlan tenant
+     * @param method the HTTP method
+     * @param url the URL of the request
+     * @param body the body of the request
+     * @param options the special modifiers of the request
+     * @param requestId unique identifier (GUID) of a single request to Atlan
+     * @param acceptType mime-type for the content accepted in the response to this query
+     * @throws AtlanException if the request cannot be initialized for any reason
+     */
+    public AtlanRequest(
+            AtlanClient client,
+            ApiResource.RequestMethod method,
+            String url,
+            String body,
+            RequestOptions options,
+            String requestId,
+            String acceptType)
+            throws AtlanException {
         try {
             this.client = client;
             this.body = body;
@@ -83,7 +107,7 @@ public class AtlanRequest {
             this.method = method;
             this.url = new URL(url);
             this.content = (body == null || body.isEmpty()) ? null : HttpContent.buildJSONEncodedContent(body);
-            this.headers = buildHeaders(true, options);
+            this.headers = buildHeaders(true, options, acceptType);
         } catch (IOException e) {
             throw new ApiConnectionException(ErrorCode.CONNECTION_ERROR, e, client.getBaseUrl());
         }
@@ -127,7 +151,7 @@ public class AtlanRequest {
                 }
             }
             this.content = HttpContent.buildMultipartFormDataContent(parameters, filename);
-            this.headers = buildHeaders(true, options);
+            this.headers = buildHeaders(true, options, "application/json");
         } catch (IOException e) {
             throw new ApiConnectionException(ErrorCode.CONNECTION_ERROR, e, client.getBaseUrl());
         }
@@ -161,13 +185,14 @@ public class AtlanRequest {
             this.method = method;
             this.url = new URL(url);
             this.content = FormEncoder.createHttpContent(map);
-            this.headers = buildHeaders(false, options);
+            this.headers = buildHeaders(false, options, "application/json");
         } catch (IOException e) {
             throw new ApiConnectionException(ErrorCode.CONNECTION_ERROR, e, client.getBaseUrl());
         }
     }
 
-    private HttpHeaders buildHeaders(boolean checkApiToken, RequestOptions provided) throws AuthenticationException {
+    private HttpHeaders buildHeaders(boolean checkApiToken, RequestOptions provided, String acceptType)
+            throws AuthenticationException {
         Map<String, List<String>> headerMap = new HashMap<>();
 
         // Request-Id + any custom headers (do these first, so they cannot clobber auth, etc)
@@ -183,7 +208,7 @@ public class AtlanRequest {
         }
 
         // Accept
-        headerMap.put("Accept", List.of("application/json"));
+        headerMap.put("Accept", List.of(acceptType));
 
         // Accept-Charset
         headerMap.put("Accept-Charset", List.of(ApiResource.CHARSET.name()));

--- a/sdk/src/main/java/com/atlan/net/AtlanResponseGetter.java
+++ b/sdk/src/main/java/com/atlan/net/AtlanResponseGetter.java
@@ -5,6 +5,7 @@ package com.atlan.net;
 /* Based on original code from https://github.com/stripe/stripe-java (under MIT license) */
 import com.atlan.AtlanClient;
 import com.atlan.exception.AtlanException;
+import com.atlan.model.core.AtlanEventStreamResponseInterface;
 import com.atlan.model.core.AtlanResponseInterface;
 import java.io.InputStream;
 import java.util.Map;
@@ -49,6 +50,30 @@ public interface AtlanResponseGetter {
      * @throws AtlanException on any API interaction problem, indicating the type of problem encountered
      */
     <T extends AtlanResponseInterface> T request(
+            AtlanClient client,
+            ApiResource.RequestMethod method,
+            String url,
+            String body,
+            Class<T> clazz,
+            RequestOptions options,
+            String requestId)
+            throws AtlanException;
+
+    /**
+     * Send a request to an Atlan API, when an event-stream response is expected.
+     *
+     * @param client connectivity to Atlan
+     * @param method to use for the request
+     * @param url of the endpoint (with all path and query parameters) for the request
+     * @param body payload for the request, if any
+     * @param clazz the expected response object type from the request
+     * @param options any alternative options to use for the request, or null to use default options
+     * @param requestId unique identifier (GUID) of a single request to Atlan
+     * @return the response of the request
+     * @param <T> the type of the response of the request
+     * @throws AtlanException on any API interaction problem, indicating the type of problem encountered
+     */
+    <T extends AtlanEventStreamResponseInterface> T requestStream(
             AtlanClient client,
             ApiResource.RequestMethod method,
             String url,

--- a/sdk/src/main/java/com/atlan/net/AtlanResponseStream.java
+++ b/sdk/src/main/java/com/atlan/net/AtlanResponseStream.java
@@ -4,8 +4,13 @@ package com.atlan.net;
 
 /* Based on original code from https://github.com/stripe/stripe-java (under MIT license) */
 import com.atlan.util.StreamUtils;
+import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Class for handling API interactions as streams.
@@ -27,10 +32,30 @@ public class AtlanResponseStream extends AbstractAtlanResponse<InputStream> {
      * Buffers the entire response body into a string, constructing the appropriate AtlanResponse
      *
      * @return the AtlanResponse
+     * @throws IOException on any errors processing the response
      */
     AtlanResponse unstream() throws IOException {
         final String bodyString = StreamUtils.readToEnd(this.body, ApiResource.CHARSET);
         this.body.close();
         return new AtlanResponse(this.code, this.headers, bodyString);
+    }
+
+    /**
+     * Buffers each line of the response body into an event, constructing the appropriate AtlanEventStreamResponse
+     *
+     * @return the AtlanEventStreamResponse
+     * @throws IOException on any errors processing the response
+     */
+    AtlanEventStreamResponse toEvents() throws IOException {
+        String line;
+        List<String> events = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(this.body, StandardCharsets.UTF_8))) {
+            while ((line = reader.readLine()) != null) {
+                if (!line.isEmpty()) {
+                    events.add(line);
+                }
+            }
+        }
+        return new AtlanEventStreamResponse(this.code, this.headers, events);
     }
 }

--- a/sdk/src/main/java/com/atlan/net/HttpURLConnectionClient.java
+++ b/sdk/src/main/java/com/atlan/net/HttpURLConnectionClient.java
@@ -53,18 +53,24 @@ public class HttpURLConnectionClient extends HttpClient {
         }
     }
 
-    /**
-     * Sends the given request to Atlan's API, and returns a buffered response.
-     *
-     * @param request the request
-     * @return the response
-     * @throws ApiConnectionException if an error occurs when sending or receiving
-     */
+    /** {@inheritDoc} */
     @Override
     public AtlanResponse request(AtlanRequest request) throws ApiConnectionException {
         final AtlanResponseStream responseStream = requestStream(request);
         try {
             return responseStream.unstream();
+        } catch (IOException e) {
+            throw new ApiConnectionException(
+                    ErrorCode.CONNECTION_ERROR, e, request.client().getBaseUrl());
+        }
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public AtlanEventStreamResponse requestES(AtlanRequest request) throws ApiConnectionException {
+        final AtlanResponseStream responseStream = requestStream(request);
+        try {
+            return responseStream.toEvents();
         } catch (IOException e) {
             throw new ApiConnectionException(
                     ErrorCode.CONNECTION_ERROR, e, request.client().getBaseUrl());

--- a/sdk/src/main/resources/templates/Connection.ftl
+++ b/sdk/src/main/resources/templates/Connection.ftl
@@ -98,16 +98,7 @@
         }
         if (adminUsers != null && !adminUsers.isEmpty()) {
             for (String userName : adminUsers) {
-                try {
-                    client.getUserCache().getIdForName(userName);
-                } catch (NotFoundException e) {
-                    // If we cannot find the username, fallback to looking for an API token
-                    ApiToken token = client.apiTokens.getById(userName);
-                    if (token == null) {
-                        // If that also turns up no results, re-throw the NotFoundException
-                        throw e;
-                    }
-                }
+                client.getUserCache().getIdForName(userName);
             }
             adminFound = true;
             builder.adminUsers(adminUsers);
@@ -177,16 +168,7 @@
         }
         if (adminUsers != null && !adminUsers.isEmpty()) {
             for (String userName : adminUsers) {
-                try {
-                    client.getUserCache().getIdForName(userName);
-                } catch (NotFoundException e) {
-                    // If we cannot find the username, fallback to looking for an API token
-                    ApiToken token = client.apiTokens.getById(userName);
-                    if (token == null) {
-                        // If that also turns up no results, re-throw the NotFoundException
-                        throw e;
-                    }
-                }
+                client.getUserCache().getIdForName(userName);
             }
         }
         return client.assets.save(this, false);
@@ -254,16 +236,7 @@
         }
         if (adminUsers != null && !adminUsers.isEmpty()) {
             for (String userName : adminUsers) {
-                try {
-                    client.getUserCache().getIdForName(userName);
-                } catch (NotFoundException e) {
-                    // If we cannot find the username, fallback to looking for an API token
-                    ApiToken token = client.apiTokens.getById(userName);
-                    if (token == null) {
-                        // If that also turns up no results, re-throw the NotFoundException
-                        throw e;
-                    }
-                }
+                client.getUserCache().getIdForName(userName);
             }
         }
         return client.assets.save(this, replaceAtlanTags);

--- a/sdk/src/test/java/com/atlan/model/admin/ApiTokenTest.java
+++ b/sdk/src/test/java/com/atlan/model/admin/ApiTokenTest.java
@@ -25,7 +25,6 @@ public class ApiTokenTest {
                     .displayName("displayName")
                     .persona(ApiToken.ApiTokenPersona.of("id1", "default_persona1", "default/persona1"))
                     .persona(ApiToken.ApiTokenPersona.of("id2", "default_persona2", "default/persona2"))
-                    .purposes("purposes")
                     .workspacePermission("abc")
                     .workspacePermission("def")
                     .build())


### PR DESCRIPTION
- (Experimental) Adds ability to stream SQL query results
- Fixes portion of API token payload dealing with assigned personas
- Moves validation of API tokens as users to user cache (no longer connection-specific)
- Adds integration test that demonstrates applying persona data policy to grant access to querying + purpose policy to redact sensitive data through such a query — all applied to an API token's ability to run SQL queries against data