### PR TITLE
Fixes for OpenAPI spec loader

### DIFF
--- a/samples/packages/openapi-spec-loader/build.gradle.kts
+++ b/samples/packages/openapi-spec-loader/build.gradle.kts
@@ -20,6 +20,7 @@ tasks {
             include(dependency("io.swagger.core.v3:swagger-core:.*"))
             include(dependency("io.swagger.parser.v3:swagger-parser-core:.*"))
             include(dependency("io.swagger.parser.v3:swagger-parser-v3:.*"))
+            include(dependency("io.swagger.parser.v3:swagger-parser-safe-url-resolver:.*"))
             include(dependency("io.swagger.core.v3:swagger-annotations:.*"))
             include(dependency("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:.*"))
             include(dependency("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:.*"))

--- a/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
+++ b/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
@@ -30,7 +30,9 @@ object OpenAPISpecLoader {
         val specUrl = Utils.getOrDefault(config.specUrl, "")
         val batchSize = 20
 
-        val inputQN = config.connectionQualifiedName?.let { it[0] }
+        val inputQN = config.connectionQualifiedName?.let {
+            if (it.isNotEmpty()) it[0] else null
+        }
         val connectionQN =
             Utils.createOrReuseConnection(config.connectionUsage, inputQN, config.connection)
 


### PR DESCRIPTION
- `ClassNotFoundException` on URL resolution
- `IndexOutOfBoundsException` in certain configurations when rerunning an existing workflow