### PR TITLE
Adds alternative connector type (`MODEL`) for data models

### DIFF
--- a/sdk/src/main/java/com/atlan/model/enums/AtlanConnectorType.java
+++ b/sdk/src/main/java/com/atlan/model/enums/AtlanConnectorType.java
@@ -118,6 +118,7 @@ public enum AtlanConnectorType implements AtlanEnum {
     SYNDIGO("syndigo", AtlanConnectionCategory.SAAS),
     PREFECT("prefect", AtlanConnectionCategory.ELT),
     DATA_MODELING("dm", AtlanConnectionCategory.DATABASE),
+    MODEL("model", AtlanConnectionCategory.DATABASE),
     APPLICATION("application", AtlanConnectionCategory.SAAS),
     UNKNOWN_CUSTOM("(custom)", AtlanConnectionCategory.API),
     ;


### PR DESCRIPTION
- I've just added a new connector type (`MODEL`) instead of updating the existing `DATA_MODELING`, as I noticed `DM` assets are currently present in [`atlan.model.assets`](https://github.com/atlanhq/atlan-java/blob/main/sdk/src/main/java/com/atlan/model/assets).