### PR TITLE
DVX-726: Fixed generalization-specialization relationship attribute names for the data model assets

### DIFF
--- a/samples/typedefs/src/main/resources/DataModel.pkl
+++ b/samples/typedefs/src/main/resources/DataModel.pkl
@@ -271,13 +271,13 @@ customTypes {
         description = "Represents the generalization-specialization relationship between a general entity (parent) and specialized entities (children)."
         parent {
           type = "\(t)\(dmEntity)"
-          attribute = "\(a)\(dmEntity)\(generalization)Entity"
-          description = "General entity, representing shared characteristics of specialized entities."
+          attribute = "\(a)\(dmEntity)\(specialization)Entities"
+          description = "Specialized entities derived from the general entity."
         }
         children {
           type = "\(t)\(dmEntity)"
-          attribute = "\(a)\(dmEntity)\(specialization)Entities"
-          description = "Specialized entities derived from the general entity."
+          attribute = "\(a)\(dmEntity)\(generalization)Entity"
+          description = "General entity, representing shared characteristics of specialized entities."
         }
       }
     }


### PR DESCRIPTION
Currently, the relationship attributes are generated with the following names (which looks incorrect comparing with the types ie: `List[Entity]`):

```diff
+        model_entity_generalization_entity: Optional[List[ModelEntity]] = Field(
+            default=None, description=""
+        )  # relationship
+        model_entity_specialization_entities: Optional[ModelEntity] = Field(
+            default=None, description=""
+        )  # relationship
```

To fix this, I’ll swap the child attribute name with the parent one (similar to the `model-version` relationship), which should resolve the issue 🤞