### PR TITLE
Asset import improvements

### DIFF
--- a/samples/packages/asset-import/src/main/kotlin/com/atlan/pkg/aim/AssetImporter.kt
+++ b/samples/packages/asset-import/src/main/kotlin/com/atlan/pkg/aim/AssetImporter.kt
@@ -251,9 +251,11 @@ class AssetImporter(
 
     /** {@inheritDoc} */
     override fun import(columnsToSkip: Set<String>): ImportResults? {
+        val colsToSkip = columnsToSkip.toMutableSet()
+        colsToSkip.add(Asset.GUID.atlanFieldName)
         if (updateOnly) {
             // If we're only updating, process as before (in-parallel, any order)
-            return super.import(columnsToSkip)
+            return super.import(colsToSkip)
         } else {
             // Otherwise, we need to do multi-pass loading:
             //  - Import assets in tiered order, top-to-bottom
@@ -271,7 +273,7 @@ class AssetImporter(
             typeLoadingOrder.forEach {
                 typeToProcess = it
                 logger.info { "--- Importing $typeToProcess assets... ---" }
-                val results = super.import(columnsToSkip)
+                val results = super.import(colsToSkip)
                 individualResults.add(results)
             }
             return ImportResults.combineAll(Atlan.getDefaultClient(), true, *individualResults.toTypedArray())

--- a/sdk/src/main/java/com/atlan/util/AssetBatch.java
+++ b/sdk/src/main/java/com/atlan/util/AssetBatch.java
@@ -521,7 +521,7 @@ public class AssetBatch implements Closeable {
                             addPartialAsset(asset, revised);
                         } else if (creationHandling == AssetCreationHandling.FULL) {
                             // Still create it (full), if not found and full asset creation is allowed
-                            revised.addAll(_batch);
+                            revised.add(asset);
                         } else {
                             // Otherwise, if it still does not match any fallback and cannot be created, skip it
                             track(skipped, asset);

--- a/sdk/src/main/java/com/atlan/util/AssetBatch.java
+++ b/sdk/src/main/java/com/atlan/util/AssetBatch.java
@@ -20,6 +20,7 @@ import com.atlan.model.core.AsyncCreationResponse;
 import com.atlan.model.enums.AssetCreationHandling;
 import com.atlan.model.relations.Reference;
 import com.atlan.model.search.FluentSearch;
+import com.atlan.model.search.IndexSearchDSL;
 import com.atlan.serde.Serde;
 import java.io.Closeable;
 import java.io.IOException;
@@ -485,11 +486,12 @@ public class AssetBatch implements Closeable {
                 } else {
                     builder = client.assets.select(true).where(Asset.QUALIFIED_NAME.in(qualifiedNames));
                 }
-                builder.pageSize(maxSize).stream().forEach(asset -> {
-                    AssetIdentity assetId =
-                            new AssetIdentity(asset.getTypeName(), asset.getQualifiedName(), caseInsensitive);
-                    found.put(assetId, asset.getQualifiedName());
-                });
+                builder.pageSize(Math.max(maxSize * 2, IndexSearchDSL.DEFAULT_PAGE_SIZE)).stream()
+                        .forEach(asset -> {
+                            AssetIdentity assetId =
+                                    new AssetIdentity(asset.getTypeName(), asset.getQualifiedName(), caseInsensitive);
+                            found.put(assetId, asset.getQualifiedName());
+                        });
                 revised = new ArrayList<>();
                 for (Asset asset : _batch) {
                     AssetIdentity assetId =


### PR DESCRIPTION
- Increase page size used for case-insensitive matching, for minor performance improvement
- Ignore GUID in any technical assets input CSV, to avoid potential 500 errors when doing case-insensitive matching and with multiple assets having the same case-insensitive qualifiedName (but actually being different assets, and thus having different GUIDs)