### PR TITLE
FT-824 Create method to update packages to use latest version of image

### DIFF
--- a/package-toolkit/config/src/main/resources/Renderers.pkl
+++ b/package-toolkit/config/src/main/resources/Renderers.pkl
@@ -341,7 +341,9 @@ const function getDockerfilePy(pkgName: String): FileOutput = new FileOutput {
           org.opencontainers.image.licenses=Apache-2
 
     COPY requirements.txt requirements.txt
-    ADD \(pkgName) /app/\(pkgName)
+    COPY \(pkgName) /app/\(pkgName)
+    COPY package.pkl /app/package.pkl
+    COPY version.txt /app/version.txt
 
     RUN wget -O /usr/local/bin/dumb-init https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 \\
             && chmod +x /usr/local/bin/dumb-init \\


### PR DESCRIPTION
Updated generated Dockerfile to facilitate updating packages with latest versions of images.

- Added package.pkl and version.txt so image so that they can be copied from the image and used to generated the workflow files in marketplace-packages repo.
- Changed ADD statements to COPY statements in accordance with [Docker recommendation](https://www.docker.com/blog/docker-best-practices-understanding-the-differences-between-add-and-copy-instructions-in-dockerfiles/)