### PR TITLE
Extend debug info for off-heap cache management

### DIFF
--- a/sdk/src/main/java/com/atlan/cache/AbstractOffHeapCache.java
+++ b/sdk/src/main/java/com/atlan/cache/AbstractOffHeapCache.java
@@ -51,6 +51,7 @@ public abstract class AbstractOffHeapCache<K, V> implements AtlanCloseable {
         lock.writeLock().lock();
         try {
             backingStore = Files.createTempDirectory("rdb_" + name + "_");
+            log.debug("Opening off-heap cache ({}): {}", this.name, this.backingStore);
             internal = RocksDB.open(backingStore.toString());
         } catch (IOException | RocksDBException e) {
             throw new RuntimeException("Unable to create off-heap cache for tracking.", e);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Add a debug log in `AbstractOffHeapCache` constructor to log cache name and backing directory when opening RocksDB.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c30bbcbf529201922eb2014677115d31545d77c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->