### PR TITLE
Adds integration test to confirm OAuth methods

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/OAuthTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/OAuthTest.java
@@ -1,0 +1,159 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2024 Atlan Pte. Ltd. */
+package com.atlan.java.sdk;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+import com.atlan.AtlanClient;
+import com.atlan.exception.AtlanException;
+import com.atlan.model.admin.OAuthClient;
+import com.atlan.model.admin.OAuthClientResponse;
+import com.atlan.model.assets.Glossary;
+import java.io.IOException;
+import java.util.Set;
+import lombok.extern.slf4j.Slf4j;
+import org.testng.annotations.Test;
+
+@Slf4j
+public class OAuthTest extends AtlanLiveTest {
+
+    private static final String PREFIX = makeUnique("OAuth");
+    private static final String CLIENT_NAME = PREFIX;
+
+    private static OAuthClient oauthGuest = null;
+    private static AtlanClient guestClient = null;
+
+    /** Create a new OAuth client.
+     *
+     * @param client connectivity to the Atlan tenant
+     * @param name of the client
+     * @param description to give the client
+     * @param personaQNs qualifiedNames of personas to bind to the client
+     * @param role workspace role to which to bind the client
+     * @return the created client
+     * @throws AtlanException on any errors creating the client
+     */
+    static OAuthClient createOAuthClient(
+            AtlanClient client, String name, String description, Set<String> personaQNs, String role)
+            throws AtlanException {
+        OAuthClient created = OAuthClient.create(client, name, description, personaQNs, role);
+        assertNotNull(created);
+        assertNotNull(created.getClientId());
+        assertNotNull(created.getClientSecret());
+        assertNotNull(created.getTokenExpirySeconds());
+        assertNotNull(created.getCreatedBy());
+        assertNotNull(created.getCreatedAt());
+        assertEquals(created.getDisplayName(), name);
+        assertEquals(created.getDescription(), description);
+        return created;
+    }
+
+    /**
+     * Delete (purge) an OAuth client based on its clientId.
+     *
+     * @param client connectivity to the Atlan tenant
+     * @param clientId unique identifier of the OAuth client
+     * @throws AtlanException on any errors purging the client
+     */
+    static void deleteOAuthClient(AtlanClient client, String clientId) throws AtlanException {
+        OAuthClient.delete(client, clientId);
+    }
+
+    @Test(groups = {"oauth.create.guest"})
+    void createGuestClient() throws AtlanException {
+        oauthGuest = createOAuthClient(client, CLIENT_NAME, "Guest client.", Set.of(), "$guest");
+        String clientId = oauthGuest.getClientId();
+        String secret = oauthGuest.getClientSecret();
+        assertNotNull(clientId);
+        assertNotNull(secret);
+        guestClient = new AtlanClient(System.getenv("ATLAN_BASE_URL"), clientId, secret);
+    }
+
+    @Test(
+            groups = {"oauth.read.clients"},
+            dependsOnGroups = {"oauth.create.guest"})
+    void retrieveClients() throws AtlanException {
+        OAuthClientResponse response = client.oauthClients.list();
+        assertNotNull(response);
+        assertTrue(response.getTotalRecord() > 1);
+        boolean found = false;
+        for (OAuthClient one : response.getRecords()) {
+            String displayName = one.getDisplayName();
+            found = CLIENT_NAME.equals(displayName) && oauthGuest.getClientId().equals(one.getClientId());
+            if (found) break;
+        }
+        assertTrue(found);
+    }
+
+    @Test(
+            groups = {"oauth.read.guest"},
+            dependsOnGroups = {"oauth.create.guest"})
+    void retrieveGuestClientByName() throws AtlanException {
+        OAuthClient retrieved = OAuthClient.retrieveByName(client, CLIENT_NAME);
+        assertNotNull(retrieved);
+        assertEquals(retrieved.getDisplayName(), CLIENT_NAME);
+        assertNotNull(retrieved.getId());
+        assertEquals(oauthGuest.getClientId(), retrieved.getClientId());
+        assertNull(retrieved.getClientSecret());
+        assertEquals(retrieved.getRole(), "$guest");
+        assertTrue(
+                retrieved.getPersonaQNs() == null || retrieved.getPersonaQNs().isEmpty());
+    }
+
+    @Test(
+            groups = {"oauth.update.guest"},
+            dependsOnGroups = {"oauth.read.guest"})
+    void updateGuestClient() throws AtlanException {
+        final String description = "Now with a revised description.";
+        OAuthClient updated =
+                client.oauthClients.update(oauthGuest.getClientId(), oauthGuest.getDisplayName(), description);
+        assertNotNull(updated);
+        assertEquals(updated.getDescription(), description);
+        assertEquals(updated.getDisplayName(), CLIENT_NAME);
+    }
+
+    @Test(
+            groups = {"oauth.use.guest"},
+            dependsOnGroups = {"oauth.update.guest"})
+    void findGlossariesAsGuest() throws AtlanException {
+        long glossaryCount = Glossary.select(guestClient).count();
+        assertTrue(glossaryCount > 1);
+    }
+
+    @Test(
+            groups = {"oauth.use.guest"},
+            dependsOnGroups = {"oauth.update.guest"})
+    void createGlossaryAsGuest() throws AtlanException {
+        Glossary toCreate = Glossary.creator(CLIENT_NAME).build();
+        toCreate.save(guestClient);
+        // TODO: find exception here...
+    }
+
+    @Test(
+            groups = {"oauth.purge.guest"},
+            dependsOnGroups = {"oauth.create.*", "oauth.read.*", "oauth.update.*", "oauth.use.*"},
+            alwaysRun = true)
+    void purgeGuest() throws AtlanException {
+        if (oauthGuest != null) {
+            deleteOAuthClient(client, oauthGuest.getClientId());
+        } else {
+            OAuthClient local = client.oauthClients.get(CLIENT_NAME);
+            if (local != null) {
+                deleteOAuthClient(client, local.getClientId());
+            }
+        }
+    }
+
+    @Test(
+            groups = {"oauth.purge.client"},
+            dependsOnGroups = {"oauth.create.*", "oauth.read.*", "oauth.update.*", "oauth.use.*"},
+            alwaysRun = true)
+    void closeTemporaryClient() throws IOException {
+        if (guestClient != null) {
+            guestClient.close();
+        }
+    }
+}

--- a/integration-tests/src/test/java/com/atlan/java/sdk/OAuthTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/OAuthTest.java
@@ -5,10 +5,12 @@ package com.atlan.java.sdk;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 import com.atlan.AtlanClient;
 import com.atlan.exception.AtlanException;
+import com.atlan.exception.PermissionException;
 import com.atlan.model.admin.OAuthClient;
 import com.atlan.model.admin.OAuthClientResponse;
 import com.atlan.model.assets.Glossary;
@@ -126,10 +128,9 @@ public class OAuthTest extends AtlanLiveTest {
     @Test(
             groups = {"oauth.use.guest"},
             dependsOnGroups = {"oauth.update.guest"})
-    void createGlossaryAsGuest() throws AtlanException {
+    void cannotCreateGlossaryAsGuest() {
         Glossary toCreate = Glossary.creator(CLIENT_NAME).build();
-        toCreate.save(guestClient);
-        // TODO: find exception here...
+        assertThrows(PermissionException.class, () -> toCreate.save(guestClient));
     }
 
     @Test(

--- a/sdk/src/main/java/com/atlan/AtlanClient.java
+++ b/sdk/src/main/java/com/atlan/AtlanClient.java
@@ -523,11 +523,10 @@ public class AtlanClient implements AtlanCloseable {
      * Add the necessary authorization details to the headers for a request.
      *
      * @param headers to which to add the authorization details
-     * @param validate whether to validate the presence of the credentials
      * @throws AtlanException on any API communication issue
      */
-    public void addAuthHeader(Map<String, List<String>> headers, boolean validate) throws AtlanException {
-        headers.put("Authorization", List.of(tokenManager.getHeader(this, validate)));
+    public void addAuthHeader(Map<String, List<String>> headers) throws AtlanException {
+        headers.put("Authorization", List.of(tokenManager.getHeader(this)));
     }
 
     /**

--- a/sdk/src/main/java/com/atlan/api/OAuthClientsEndpoint.java
+++ b/sdk/src/main/java/com/atlan/api/OAuthClientsEndpoint.java
@@ -222,8 +222,8 @@ public class OAuthClientsEndpoint extends HeraclesEndpoint {
             throws AtlanException {
         String url = String.format("%s%s/%s", getBaseUrl(), endpoint, clientId);
         OAuthClientRequest ocr = new OAuthClientRequest(displayName, description, null, null);
-        WrappedOAuthClient response = ApiResource.request(
-                client, ApiResource.RequestMethod.POST, url, ocr, WrappedOAuthClient.class, options);
+        WrappedOAuthClient response =
+                ApiResource.request(client, ApiResource.RequestMethod.PUT, url, ocr, WrappedOAuthClient.class, options);
         if (response != null) {
             OAuthClient token = response.getToken();
             token.setRawJsonObject(response.getRawJsonObject());
@@ -277,6 +277,11 @@ public class OAuthClientsEndpoint extends HeraclesEndpoint {
             throws AtlanException {
         String url = String.format("%s%s", getBaseUrl(), exchangeEndpoint);
         OAuthExchangeRequest oer = new OAuthExchangeRequest(clientId, clientSecret);
+        if (options == null) {
+            options = RequestOptions.from(client).sendAuthHeader(false).build();
+        } else {
+            options = options.toBuilder().sendAuthHeader(false).build();
+        }
         return ApiResource.request(
                 client, ApiResource.RequestMethod.POST, url, oer, OAuthExchangeResponse.class, options);
     }

--- a/sdk/src/main/java/com/atlan/auth/TokenManager.java
+++ b/sdk/src/main/java/com/atlan/auth/TokenManager.java
@@ -33,19 +33,16 @@ public abstract class TokenManager {
      * Retrieve the header to use for Authorization using this token.
      *
      * @param client through which to retrieve the token (if a refresh is needed)
-     * @param validate whether to validate the token before returning it
      * @return the value for the Authorization header
      * @throws AtlanException on any API communication issue during attempted refresh (if needed)
      */
-    public final String getHeader(AtlanClient client, boolean validate) throws AtlanException {
+    public final String getHeader(AtlanClient client) throws AtlanException {
         if (token == null) {
             refresh(client);
         }
         lock.readLock().lock();
         try {
-            if (validate) {
-                validate();
-            }
+            validate();
             return getAuthHeader();
         } finally {
             lock.readLock().unlock();

--- a/sdk/src/main/java/com/atlan/model/admin/OAuthClient.java
+++ b/sdk/src/main/java/com/atlan/model/admin/OAuthClient.java
@@ -12,6 +12,7 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 import lombok.extern.jackson.Jacksonized;
 
+@Getter
 @Jacksonized
 @SuperBuilder(toBuilder = true)
 @EqualsAndHashCode(callSuper = true)
@@ -27,6 +28,9 @@ public class OAuthClient extends AtlanObject {
 
     /** Unique client identifier (prefixed GUID) of the OAuth client. */
     String clientId;
+
+    /** Unique secret used to authorize exchanging for bearer tokens. */
+    String clientSecret;
 
     /** Human-readable name provided when creating the client. */
     String displayName;
@@ -48,7 +52,7 @@ public class OAuthClient extends AtlanObject {
     String role;
 
     /** Lifespan of each exchanged token for the OAuth client. */
-    Long tokenExpiryInSeconds;
+    Long tokenExpirySeconds;
 
     /** Epoch time, in milliseconds, at which the OAuth client was last updated. */
     String updatedAt;
@@ -59,10 +63,10 @@ public class OAuthClient extends AtlanObject {
     /**
      * Create a new OAuth client that is not assigned to any personas.
      *
-     * @param client connectivity to the Atlan tenant on which to create the new API token
-     * @param displayName readable name for the API token
+     * @param client connectivity to the Atlan tenant on which to create the new OAuth client
+     * @param displayName readable name for the OAuth client
      * @param role workspace role the client should be bound to
-     * @return the API token details
+     * @return the OAuth client details
      * @throws AtlanException on any API communication issues
      */
     public static OAuthClient create(AtlanClient client, String displayName, String role) throws AtlanException {
@@ -70,14 +74,14 @@ public class OAuthClient extends AtlanObject {
     }
 
     /**
-     * Create a new API token with the provided details.
+     * Create a new OAuth client with the provided details.
      *
-     * @param client connectivity to the Atlan tenant on which to create the new API token
-     * @param displayName readable name for the API token
-     * @param description explanation of the API token
-     * @param personas unique names (qualifiedNames) of personas that should be linked to the token
+     * @param client connectivity to the Atlan tenant on which to create the new OAuth client
+     * @param displayName readable name for the OAuth client
+     * @param description explanation of the OAuth client
+     * @param personas unique names (qualifiedNames) of personas that should be linked to the client
      * @param role workspace role the client should be bound to
-     * @return the API token details
+     * @return the OAuth client details
      * @throws AtlanException on any API communication issues
      */
     public static OAuthClient create(
@@ -87,11 +91,11 @@ public class OAuthClient extends AtlanObject {
     }
 
     /**
-     * Retrieves the API token with a name that exactly matches the provided string.
+     * Retrieves the OAuth client with a name that exactly matches the provided string.
      *
-     * @param client connectivity to the Atlan tenant from which to retrieve the API token
-     * @param displayName name (as it appears in the UI) by which to retrieve the API token
-     * @return the API token whose name (in the UI) contains the provided string, or null if there is none
+     * @param client connectivity to the Atlan tenant from which to retrieve the OAuth client
+     * @param displayName name (as it appears in the UI) by which to retrieve the OAuth client
+     * @return the OAuth client whose name (in the UI) contains the provided string, or null if there is none
      * @throws AtlanException on any error during API invocation
      */
     public static OAuthClient retrieveByName(AtlanClient client, String displayName) throws AtlanException {
@@ -99,12 +103,12 @@ public class OAuthClient extends AtlanObject {
     }
 
     /**
-     * Sends this API token to Atlan to update it in Atlan.
+     * Sends this OAuth client to Atlan to update it in Atlan.
      * Note: only the displayName and description can currently be updated (for anything else,
      * you need to create a new OAuth client).
      *
-     * @param client connectivity to the Atlan tenant on which to update the API token
-     * @return the updated API token
+     * @param client connectivity to the Atlan tenant on which to update the OAuth client
+     * @return the updated OAuth client
      * @throws AtlanException on any error during API invocation
      */
     public OAuthClient update(AtlanClient client) throws AtlanException {
@@ -118,13 +122,13 @@ public class OAuthClient extends AtlanObject {
     }
 
     /**
-     * Delete (purge) the API token with the provided GUID.
+     * Delete (purge) the OAuth client with the provided clientId.
      *
-     * @param client connectivity to the Atlan tenant from which to remove the API token
-     * @param guid unique identifier (GUID) of the API token to hard-delete
+     * @param client connectivity to the Atlan tenant from which to remove the OAuth client
+     * @param clientId unique identifier of the OAuth client to hard-delete
      * @throws AtlanException on any API communication issues
      */
-    public static void delete(AtlanClient client, String guid) throws AtlanException {
-        client.oauthClients.purge(guid);
+    public static void delete(AtlanClient client, String clientId) throws AtlanException {
+        client.oauthClients.purge(clientId);
     }
 }

--- a/sdk/src/main/java/com/atlan/net/AtlanRequest.java
+++ b/sdk/src/main/java/com/atlan/net/AtlanRequest.java
@@ -244,7 +244,9 @@ public class AtlanRequest {
         headerMap.put("Accept-Charset", List.of(ApiResource.CHARSET.name()));
 
         // Authorization
-        client.addAuthHeader(headerMap, checkApiToken);
+        if (checkApiToken && (provided == null || provided.getSendAuthHeader())) {
+            client.addAuthHeader(headerMap);
+        }
 
         return HttpHeaders.of(headerMap);
     }

--- a/sdk/src/main/java/com/atlan/net/RequestOptions.java
+++ b/sdk/src/main/java/com/atlan/net/RequestOptions.java
@@ -31,6 +31,9 @@ public class RequestOptions {
     @Builder.Default
     private final boolean skipLogging = false;
 
+    @Builder.Default
+    private final boolean sendAuthHeader = true;
+
     @Singular
     private final Map<String, List<String>> extraHeaders;
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds OAuth client lifecycle integration tests and updates SDK to conditionally send auth headers, switch update to PUT, and extend OAuth client model.
> 
> - **Integration Tests**:
>   - Add `integration-tests/src/test/java/com/atlan/java/sdk/OAuthTest.java` covering OAuth client create/list/retrieve/update/use and cleanup; validates guest permissions.
> - **SDK/Auth Handling**:
>   - `AtlanClient.addAuthHeader` and `TokenManager.getHeader` simplified (always validate); signatures updated.
>   - `RequestOptions`: add `sendAuthHeader` (default true) and use it in `AtlanRequest` to conditionally include `Authorization`.
>   - `OAuthClientsEndpoint.exchange(...)`: ensures `sendAuthHeader(false)` so bearer auth isn’t sent; `update(...)` now uses HTTP `PUT`.
> - **Model**:
>   - `OAuthClient`: add `clientSecret`, rename `tokenExpiryInSeconds` to `tokenExpirySeconds`, update docs/methods; `delete(...)` now accepts `clientId`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c4cf3a067d0eea421b23153c04550c6ee7afe490. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->