### PR TITLE
Revert connection validations to previous state

### DIFF
--- a/sdk/src/main/java/com/atlan/model/assets/Connection.java
+++ b/sdk/src/main/java/com/atlan/model/assets/Connection.java
@@ -540,7 +540,7 @@ public class Connection extends Asset implements IConnection, IAsset, IReference
                 .connectorType(connectorType);
         if (adminRoles != null && !adminRoles.isEmpty()) {
             for (String roleId : adminRoles) {
-                client.getRoleCache().getNameForSid(roleId);
+                client.getRoleCache().getNameForId(roleId);
             }
             adminFound = true;
             builder.adminRoles(adminRoles);
@@ -631,7 +631,7 @@ public class Connection extends Asset implements IConnection, IAsset, IReference
                 .customConnectorType(connectorName);
         if (adminRoles != null && !adminRoles.isEmpty()) {
             for (String roleId : adminRoles) {
-                client.getRoleCache().getNameForSid(roleId);
+                client.getRoleCache().getNameForId(roleId);
             }
             adminFound = true;
             builder.adminRoles(adminRoles);
@@ -679,7 +679,7 @@ public class Connection extends Asset implements IConnection, IAsset, IReference
         // (the cache retrievals will throw errors directly if there are any)
         if (adminRoles != null && !adminRoles.isEmpty()) {
             for (String roleId : adminRoles) {
-                client.getRoleCache().getNameForSid(roleId);
+                client.getRoleCache().getNameForId(roleId);
             }
         }
         if (adminGroups != null && !adminGroups.isEmpty()) {
@@ -714,7 +714,7 @@ public class Connection extends Asset implements IConnection, IAsset, IReference
         // (the cache retrievals will throw errors directly if there are any)
         if (adminRoles != null && !adminRoles.isEmpty()) {
             for (String roleId : adminRoles) {
-                client.getRoleCache().getNameForSid(roleId);
+                client.getRoleCache().getNameForId(roleId);
             }
         }
         if (adminGroups != null && !adminGroups.isEmpty()) {

--- a/sdk/src/main/resources/templates/Connection.ftl
+++ b/sdk/src/main/resources/templates/Connection.ftl
@@ -97,7 +97,7 @@
                 .connectorType(connectorType);
         if (adminRoles != null && !adminRoles.isEmpty()) {
             for (String roleId : adminRoles) {
-                client.getRoleCache().getNameForSid(roleId);
+                client.getRoleCache().getNameForId(roleId);
             }
             adminFound = true;
             builder.adminRoles(adminRoles);
@@ -185,7 +185,7 @@
                 .customConnectorType(connectorName);
         if (adminRoles != null && !adminRoles.isEmpty()) {
             for (String roleId : adminRoles) {
-                client.getRoleCache().getNameForSid(roleId);
+                client.getRoleCache().getNameForId(roleId);
             }
             adminFound = true;
             builder.adminRoles(adminRoles);
@@ -233,7 +233,7 @@
         // (the cache retrievals will throw errors directly if there are any)
         if (adminRoles != null && !adminRoles.isEmpty()) {
             for (String roleId : adminRoles) {
-                client.getRoleCache().getNameForSid(roleId);
+                client.getRoleCache().getNameForId(roleId);
             }
         }
         if (adminGroups != null && !adminGroups.isEmpty()) {
@@ -269,7 +269,7 @@
         // (the cache retrievals will throw errors directly if there are any)
         if (adminRoles != null && !adminRoles.isEmpty()) {
             for (String roleId : adminRoles) {
-                client.getRoleCache().getNameForSid(roleId);
+                client.getRoleCache().getNameForId(roleId);
             }
         }
         if (adminGroups != null && !adminGroups.isEmpty()) {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches role validation to use getNameForId across Connection creator and save flows in both Java and template.
> 
> - **SDK (Java)**:
>   - Update `sdk/src/main/java/com/atlan/model/assets/Connection.java` to validate admin roles via `client.getRoleCache().getNameForId(...)` in:
>     - `creator(AtlanClient, String, AtlanConnectorType, ...)`
>     - `creator(AtlanClient, String, String, AtlanConnectionCategory, ...)`
>     - `save(AtlanClient)` and deprecated `save(AtlanClient, boolean)`
> - **Templates**:
>   - Mirror the same change in `sdk/src/main/resources/templates/Connection.ftl` for corresponding `creator(...)` and `save(...)` methods.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0da65dba76790c7b84fecbe1d1e7161f4fe3795e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->