### PR TITLE
Fix integration tests for role cache changes

### DIFF
--- a/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/cell/RoleXformer.kt
+++ b/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/cell/RoleXformer.kt
@@ -38,11 +38,16 @@ object RoleXformer {
     ): String {
         return when (fieldName) {
             in FIELDS -> {
-                try {
-                    // Try to look up the user reference by username
-                    return ctx.client.roleCache.getIdForName(roleRef)
+                return try {
+                    // Try to look up the role reference by role ID
+                    ctx.client.roleCache.getIdForSid(roleRef)
                 } catch (e: NotFoundException) {
-                    throw NoSuchElementException("Role name is not known to Atlan (in $fieldName): $roleRef", e)
+                    try {
+                        // Try again, this time looking up the role by name
+                        ctx.client.roleCache.getIdForName(roleRef)
+                    } catch (e: NotFoundException) {
+                        throw NoSuchElementException("Role name is not known to Atlan (in $fieldName): $roleRef", e)
+                    }
                 }
             }
             else -> roleRef

--- a/samples/packages/cube-assets-builder/src/test/kotlin/com/atlan/pkg/cab/CreateThenUpDeltaCABTest.kt
+++ b/samples/packages/cube-assets-builder/src/test/kotlin/com/atlan/pkg/cab/CreateThenUpDeltaCABTest.kt
@@ -208,7 +208,7 @@ class CreateThenUpDeltaCABTest : PackageTest("ctud") {
         val c1 = found[0]
         assertEquals(conn1, c1.name)
         assertEquals(conn1Type, c1.connectorType)
-        val adminRoleId = client.roleCache.getIdForName("\$admin")
+        val adminRoleId = client.roleCache.getIdForSid("\$admin")
         assertEquals(setOf(adminRoleId), c1.adminRoles)
         val apiToken = client.users.currentUser.username
         assertEquals(setOf("chris", apiToken), c1.adminUsers)

--- a/samples/packages/cube-assets-builder/src/test/kotlin/com/atlan/pkg/cab/CreateThenUpsertCABTest.kt
+++ b/samples/packages/cube-assets-builder/src/test/kotlin/com/atlan/pkg/cab/CreateThenUpsertCABTest.kt
@@ -200,7 +200,7 @@ class CreateThenUpsertCABTest : PackageTest("ctu") {
         val c1 = found[0]
         assertEquals(conn1, c1.name)
         assertEquals(conn1Type, c1.connectorType)
-        val adminRoleId = client.roleCache.getIdForName("\$admin")
+        val adminRoleId = client.roleCache.getIdForSid("\$admin")
         assertEquals(setOf(adminRoleId), c1.adminRoles)
         val apiToken = client.users.currentUser.username
         assertEquals(setOf("chris", apiToken), c1.adminUsers)

--- a/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CaseInsensitiveConnectorTypeTest.kt
+++ b/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CaseInsensitiveConnectorTypeTest.kt
@@ -177,7 +177,7 @@ class CaseInsensitiveConnectorTypeTest : PackageTest("cict") {
         val c1 = found[0]
         assertEquals(conn1, c1.name)
         assertEquals(conn1Type, c1.connectorType)
-        val adminRoleId = client.roleCache.getIdForName("\$admin")
+        val adminRoleId = client.roleCache.getIdForSid("\$admin")
         assertEquals(setOf(adminRoleId), c1.adminRoles)
         val apiToken = client.users.currentUser.username
         assertEquals(setOf("chris", apiToken), c1.adminUsers)

--- a/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CreateThenUpDeltaDropAllColumnsRABTest.kt
+++ b/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CreateThenUpDeltaDropAllColumnsRABTest.kt
@@ -230,7 +230,7 @@ class CreateThenUpDeltaDropAllColumnsRABTest : PackageTest("ctudac") {
         val c1 = found[0]
         assertEquals(conn1, c1.name)
         assertEquals(conn1Type, c1.connectorType)
-        val adminRoleId = client.roleCache.getIdForName("\$admin")
+        val adminRoleId = client.roleCache.getIdForSid("\$admin")
         assertEquals(setOf(adminRoleId), c1.adminRoles)
         val apiToken = client.users.currentUser.username
         assertEquals(setOf("chris", apiToken), c1.adminUsers)

--- a/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CreateThenUpDeltaRABTest.kt
+++ b/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CreateThenUpDeltaRABTest.kt
@@ -229,7 +229,7 @@ class CreateThenUpDeltaRABTest : PackageTest("ctud") {
         val c1 = found[0]
         assertEquals(conn1, c1.name)
         assertEquals(conn1Type, c1.connectorType)
-        val adminRoleId = client.roleCache.getIdForName("\$admin")
+        val adminRoleId = client.roleCache.getIdForSid("\$admin")
         assertEquals(setOf(adminRoleId), c1.adminRoles)
         val apiToken = client.users.currentUser.username
         assertEquals(setOf("chris", apiToken), c1.adminUsers)

--- a/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CreateThenUpsertRABTest.kt
+++ b/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CreateThenUpsertRABTest.kt
@@ -220,7 +220,7 @@ class CreateThenUpsertRABTest : PackageTest("ctu") {
         val c1 = found[0]
         assertEquals(conn1, c1.name)
         assertEquals(conn1Type, c1.connectorType)
-        val adminRoleId = client.roleCache.getIdForName("\$admin")
+        val adminRoleId = client.roleCache.getIdForSid("\$admin")
         assertEquals(setOf(adminRoleId), c1.adminRoles)
         val apiToken = client.users.currentUser.username
         assertEquals(setOf("chris", apiToken), c1.adminUsers)

--- a/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/PartialAssetsTest.kt
+++ b/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/PartialAssetsTest.kt
@@ -178,7 +178,7 @@ class PartialAssetsTest : PackageTest("pa") {
         val c1 = found[0]
         assertEquals(conn1, c1.name)
         assertEquals(conn1Type, c1.connectorType)
-        val adminRoleId = client.roleCache.getIdForName("\$admin")
+        val adminRoleId = client.roleCache.getIdForSid("\$admin")
         assertEquals(setOf(adminRoleId), c1.adminRoles)
         val apiToken = client.users.currentUser.username
         assertEquals(setOf("chris", apiToken), c1.adminUsers)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Role decoding now resolves by SID first (fallback to name), and tests switch admin role lookups to use getIdForSid.
> 
> - **Runtime**:
>   - **Role decoding**: In `RoleXformer.decode`, resolve roles via `ctx.client.roleCache.getIdForSid` first, then fallback to `getIdForName`.
> - **Tests**:
>   - Update multiple integration tests to use `client.roleCache.getIdForSid("$admin")` when asserting `Connection.ADMIN_ROLES`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a9e79a9ca7ebec443c2b6681df09d41372031797. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->