### PR TITLE
Add retryable purging of typedefs

### DIFF
--- a/sdk/src/main/java/com/atlan/api/TypeDefsEndpoint.java
+++ b/sdk/src/main/java/com/atlan/api/TypeDefsEndpoint.java
@@ -492,7 +492,8 @@ public class TypeDefsEndpoint extends AtlasEndpoint {
         String url = String.format(
                 "%s%s",
                 getBaseUrl(), String.format("%s/name/%s", endpoint_singular, StringUtils.encodeContent(internalName)));
-        ApiResource.request(client, ApiResource.RequestMethod.DELETE, url, "", null, options);
+        executeWithRetries(
+                () -> ApiResource.request(client, ApiResource.RequestMethod.DELETE, url, "", null, options), options);
         switch (typeDef.getCategory()) {
             case ATLAN_TAG:
                 client.getAtlanTagCache().forceRefresh();


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Makes typedef purge DELETE calls retryable via a new executeWithRetries helper in AbstractEndpoint.
> 
> - **API / SDK**:
>   - **Retry Helper**: Add `executeWithRetries` to `AbstractEndpoint` (with `ThrowingSupplier`, backoff via `HttpClient.waitTime`, and `ApiException` on overrun/interruption).
>   - **TypeDef Purge**: Wrap DELETE request in `TypeDefsEndpoint.purge` with `executeWithRetries` to retry purging by internal name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8fbe05d9d170adc1255599dc06a55b9d31f5138b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->