### PR TITLE
Fixes edge case retries on certain 503 responses

### DIFF
--- a/sdk/src/main/java/com/atlan/net/HttpClient.java
+++ b/sdk/src/main/java/com/atlan/net/HttpClient.java
@@ -9,6 +9,7 @@ import com.atlan.exception.ApiConnectionException;
 import com.atlan.exception.ApiException;
 import com.atlan.exception.AtlanException;
 import com.atlan.util.Stopwatch;
+import java.io.IOException;
 import java.net.ConnectException;
 import java.net.NoRouteToHostException;
 import java.net.SocketTimeoutException;
@@ -323,6 +324,14 @@ public abstract class HttpClient {
                 }
             }
             return (response.code() == 302 || response.code() == 403 || response.code() >= 500);
+        } else {
+            if (exception != null
+                    && (exception.getCause() instanceof IOException
+                            || exception.getCause() instanceof InterruptedException)) {
+                // Or if the response was null and there is an underlying IOException or InterruptedException cause,
+                // then the network call itself (via HttpURLConnectionClient) likely failed -- and should be retried
+                return true;
+            }
         }
         return false;
     }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extends `HttpClient.shouldRetry` to retry when no response is returned and the underlying cause is an `IOException` or `InterruptedException`.
> 
> - **Retries**:
>   - In `HttpClient.shouldRetry`, when `response` is `null`, now retries if the exception cause is `IOException` or `InterruptedException`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b86c855f0774dd13bff45c73dd33ea8ce90dc644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->