### PR TITLE
Replace gradle cache action with direct artifact upload/download

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,16 +20,16 @@ jobs:
           java-version: 21
           distribution: temurin
       - name: Compile
-        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca  # v3.0.1
+        run: ./gradlew assemble shadowJar test
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
-          arguments: assemble shadowJar test
-      # - name: Upload build artifacts
-      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
-      #   with:
-      #     name: build-artifacts
-      #     path: |
-      #       integration-tests/build/classes/java/test/com/atlan/java/sdk/*.class
-      #       samples/packages/**/build/classes/kotlin/test/**/*.class
+          name: build-artifacts
+          path: |
+            **/build/libs/*.jar
+            **/build/classes/
+          retention-days: 1
+          compression-level: 0
   list-integration-tests:
     runs-on: ubuntu-latest
     outputs:
@@ -56,22 +56,28 @@ jobs:
     name: "Integration"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-      # - name: Download artifacts
-      #   uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      #   with:
-      #     name: build-artifacts
+      - name: Download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        with:
+          name: build-artifacts
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
         with:
           java-version: 21
           distribution: temurin
       - name: Integration tests
-        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca  # v3.0.1
         env:
           ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
           ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-        with:
-          arguments: -PintegrationTests integration-tests:test --tests "com.atlan.java.sdk.${{ matrix.tests }}"
+        run: ./gradlew -PintegrationTests integration-tests:test --tests "com.atlan.java.sdk.${{ matrix.tests }}" -x assemble
+      # - name: Integration tests
+      #   uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca  # v3.0.1
+      #   env:
+      #     ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
+      #     ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
+      #     NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+      #   with:
+      #     arguments: -PintegrationTests integration-tests:test --tests "com.atlan.java.sdk.${{ matrix.tests }}"
       - if: success() || failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
@@ -113,10 +119,10 @@ jobs:
       #     docker-images: false
       #     swap-storage: true
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
-      # - name: Download artifacts
-      #   uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
-      #   with:
-      #     name: build-artifacts
+      - name: Download artifacts
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16  # v4.1.8
+        with:
+          name: build-artifacts
       - uses: actions/setup-java@dded0888837ed1f317902acf8a20df0ad188d165  # v5.0.0
         with:
           java-version: 21
@@ -126,12 +132,18 @@ jobs:
           ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
           ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
-          JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/mnt"
-        uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca  # v3.0.1
-        with:
-          arguments: |
-            -PpackageTests
-            :samples:packages:${{ matrix.tests }}:test
+        run: ./gradlew -PpackageTests :samples:packages:${{ matrix.tests }}:test -x assemble
+      # - name: Package tests
+      #   env:
+      #     ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
+      #     ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
+      #     NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+      #     JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/mnt"
+      #   uses: burrunan/gradle-cache-action@663fbad34e03c8f12b27f4999ac46e3d90f87eca  # v3.0.1
+      #   with:
+      #     arguments: |
+      #       -PpackageTests
+      #       :samples:packages:${{ matrix.tests }}:test
       - if: success() || failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches workflow to run Gradle directly and uses artifact upload/download to share build outputs across jobs.
> 
> - **CI Workflow (`.github/workflows/test.yml`)**:
>   - **Build**:
>     - Replace `burrunan/gradle-cache-action` with direct `./gradlew assemble shadowJar test`.
>     - Upload `build-artifacts` (``**/build/libs/*.jar``, ``**/build/classes/``) with 1-day retention and no compression.
>   - **Integration**:
>     - Download `build-artifacts`.
>     - Run tests via direct Gradle: `./gradlew -PintegrationTests integration-tests:test --tests "com.atlan.java.sdk.${{ matrix.tests }}" -x assemble`.
>   - **Packages**:
>     - Download `build-artifacts`.
>     - Run package tests via direct Gradle: `./gradlew -PpackageTests :samples:packages:${{ matrix.tests }}:test -x assemble`.
>   - **Artifacts**:
>     - Continue uploading test logs per matrix entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbf8535f42d732d37933c927e99ce0ae015ff92c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->