### PR TITLE
feat: APIMethod SDK type and OpenAPI Spec loader enhancements

### DIFF
--- a/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
+++ b/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
@@ -273,47 +273,52 @@ object OpenAPISpecLoader {
             logger.info { "Creating an APIPath for each path defined within the spec (total: $totalCount)" }
             AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { pathBatch ->
                 AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { methodBatch ->
-                    try {
-                        val assetCount = AtomicLong(0)
-                        for (apiPath in spec.paths.entries) {
-                            val pathUrl = apiPath.key
-                            val pathDetails = apiPath.value
+                    AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { inlineObjectBatch ->
+                        AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { inlineFieldBatch ->
+                            try {
+                                val assetCount = AtomicLong(0)
+                                for (apiPath in spec.paths.entries) {
+                                    val pathUrl = apiPath.key
+                                    val pathDetails = apiPath.value
 
-                            // --- APIPath creation (unchanged from original) ---
-                            val operations = mutableListOf<String>()
-                            val desc = StringBuilder()
-                            desc.append("| Method | Summary|\n|---|---|\n")
-                            addOperationDetails(pathDetails.get, "GET", operations, desc)
-                            addOperationDetails(pathDetails.post, "POST", operations, desc)
-                            addOperationDetails(pathDetails.put, "PUT", operations, desc)
-                            addOperationDetails(pathDetails.patch, "PATCH", operations, desc)
-                            addOperationDetails(pathDetails.delete, "DELETE", operations, desc)
-                            val path =
-                                APIPath
-                                    .creator(pathUrl, specQN)
-                                    .description(desc.toString())
-                                    .apiPathRawURI(pathUrl)
-                                    .apiPathSummary(pathDetails.summary)
-                                    .apiPathAvailableOperations(operations)
-                                    .apiPathIsTemplated(pathUrl.contains("{") && pathUrl.contains("}"))
-                                    .build()
-                            pathBatch.add(path)
-                            val pathQN = path.qualifiedName
+                                    // --- APIPath creation (unchanged from original) ---
+                                    val operations = mutableListOf<String>()
+                                    val desc = StringBuilder()
+                                    desc.append("| Method | Summary|\n|---|---|\n")
+                                    addOperationDetails(pathDetails.get, "GET", operations, desc)
+                                    addOperationDetails(pathDetails.post, "POST", operations, desc)
+                                    addOperationDetails(pathDetails.put, "PUT", operations, desc)
+                                    addOperationDetails(pathDetails.patch, "PATCH", operations, desc)
+                                    addOperationDetails(pathDetails.delete, "DELETE", operations, desc)
+                                    val path =
+                                        APIPath
+                                            .creator(pathUrl, specQN)
+                                            .description(desc.toString())
+                                            .apiPathRawURI(pathUrl)
+                                            .apiPathSummary(pathDetails.summary)
+                                            .apiPathAvailableOperations(operations)
+                                            .apiPathIsTemplated(pathUrl.contains("{") && pathUrl.contains("}"))
+                                            .build()
+                                    pathBatch.add(path)
+                                    val pathQN = path.qualifiedName
 
-                            // --- APIMethod creation per operation ---
-                            createMethodIfPresent(pathDetails.get, "GET", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
-                            createMethodIfPresent(pathDetails.post, "POST", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
-                            createMethodIfPresent(pathDetails.put, "PUT", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
-                            createMethodIfPresent(pathDetails.patch, "PATCH", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
-                            createMethodIfPresent(pathDetails.delete, "DELETE", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
+                                    // --- APIMethod creation per operation (with inline schema support) ---
+                                    val methods = listOf("GET" to pathDetails.get, "POST" to pathDetails.post, "PUT" to pathDetails.put, "PATCH" to pathDetails.patch, "DELETE" to pathDetails.delete)
+                                    for ((httpMethod, op) in methods) {
+                                        createMethodIfPresent(op, httpMethod, pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch, inlineObjectBatch, inlineFieldBatch)
+                                    }
 
-                            Utils.logProgress(assetCount, totalCount, logger, batchSize)
+                                    Utils.logProgress(assetCount, totalCount, logger, batchSize)
+                                }
+                                pathBatch.flush()
+                                inlineObjectBatch.flush()
+                                inlineFieldBatch.flush()
+                                methodBatch.flush()
+                                Utils.logProgress(assetCount, totalCount, logger, batchSize)
+                            } catch (e: AtlanException) {
+                                logger.error("Unable to bulk-save API paths/methods.", e)
+                            }
                         }
-                        pathBatch.flush()
-                        methodBatch.flush()
-                        Utils.logProgress(assetCount, totalCount, logger, batchSize)
-                    } catch (e: AtlanException) {
-                        logger.error("Unable to bulk-save API paths/methods.", e)
                     }
                 }
             }
@@ -341,8 +346,10 @@ object OpenAPISpecLoader {
         specQN: String,
         connectionQN: String,
         spec: OpenAPISpecReader,
-        objectQNs: Map<String, String>,
-        batch: AssetBatch,
+        objectQNs: MutableMap<String, String>,
+        methodBatch: AssetBatch,
+        objectBatch: AssetBatch,
+        fieldBatch: AssetBatch,
     ) {
         if (operation == null) return
 
@@ -372,6 +379,21 @@ object OpenAPISpecLoader {
                 if (requestObjectQN != null) {
                     methodBuilder.apiMethodRequestSchema(APIObject.refByQualifiedName(requestObjectQN))
                 }
+            } else if (requestSchema.properties != null && requestSchema.properties.isNotEmpty()) {
+                // Inline request schema with properties — create synthetic APIObject + APIFields
+                val syntheticName = "${httpMethod}_${sanitizePath(pathUrl)}_Request"
+                val syntheticQN =
+                    createInlineSchemaObject(
+                        syntheticName,
+                        requestSchema,
+                        specQN,
+                        connectionQN,
+                        spec,
+                        objectQNs,
+                        objectBatch,
+                        fieldBatch,
+                    )
+                methodBuilder.apiMethodRequestSchema(APIObject.refByQualifiedName(syntheticQN))
             }
         }
 
@@ -394,9 +416,25 @@ object OpenAPISpecLoader {
                             responseCodes[statusCode] = responseObjectQN
                             responseSchemas.add(responseObjectQN)
                         }
+                    } else if (responseSchema.properties != null && responseSchema.properties.isNotEmpty()) {
+                        // Inline response schema with properties — create synthetic APIObject + APIFields
+                        val syntheticName = "${httpMethod}_${sanitizePath(pathUrl)}_${statusCode}_Response"
+                        val syntheticQN =
+                            createInlineSchemaObject(
+                                syntheticName,
+                                responseSchema,
+                                specQN,
+                                connectionQN,
+                                spec,
+                                objectQNs,
+                                objectBatch,
+                                fieldBatch,
+                            )
+                        responseCodes[statusCode] = syntheticQN
+                        responseSchemas.add(syntheticQN)
                     } else {
-                        // Inline schema: create a synthetic APIObject name for the response codes map
-                        val inlineName = "${httpMethod}_${pathUrl.replace("/", "_").replace("{", "").replace("}", "")}_$statusCode"
+                        // Inline primitive/array schema — record in response codes map only
+                        val inlineName = "${httpMethod}_${sanitizePath(pathUrl)}_$statusCode"
                         responseCodes[statusCode] = inlineName
                     }
                 }
@@ -412,8 +450,81 @@ object OpenAPISpecLoader {
             methodBuilder.apiMethodResponseSchema(APIObject.refByQualifiedName(responseQN))
         }
 
-        batch.add(methodBuilder.build())
+        methodBatch.add(methodBuilder.build())
     }
+
+    /**
+     * Create a synthetic APIObject (and its APIFields) for an inline schema that has properties.
+     * Returns the qualified name of the created APIObject.
+     */
+    private fun createInlineSchemaObject(
+        syntheticName: String,
+        schema: Schema<*>,
+        specQN: String,
+        connectionQN: String,
+        spec: OpenAPISpecReader,
+        objectQNs: MutableMap<String, String>,
+        objectBatch: AssetBatch,
+        fieldBatch: AssetBatch,
+    ): String {
+        val objectQN = "$specQN/schemas/$syntheticName"
+        objectQNs[syntheticName] = objectQN
+        val properties = schema.properties ?: emptyMap()
+        val apiObject =
+            APIObject
+                ._internal()
+                .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                .qualifiedName(objectQN)
+                .name(syntheticName)
+                .connectionQualifiedName(connectionQN)
+                .apiSpecQualifiedName(specQN)
+                .apiSpecName(spec.title)
+                .apiSpecType(spec.openAPIVersion)
+                .apiFieldCount(properties.size.toLong())
+                .build()
+        objectBatch.add(apiObject)
+        for ((fieldName, fieldSchema) in properties) {
+            val fieldQN = "$objectQN/$fieldName"
+            val refSchemaName = extractRefSchemaName(fieldSchema)
+            val isObjectRef = refSchemaName != null
+            val fieldType = resolveFieldType(fieldSchema)
+            val fieldTypeSecondary = resolveFieldTypeSecondary(fieldSchema)
+            val fieldBuilder =
+                APIField
+                    ._internal()
+                    .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                    .qualifiedName(fieldQN)
+                    .name(fieldName)
+                    .connectionQualifiedName(connectionQN)
+                    .apiSpecQualifiedName(specQN)
+                    .apiSpecName(spec.title)
+                    .apiSpecType(spec.openAPIVersion)
+                    .apiFieldType(fieldType)
+                    .apiObject(APIObject.refByQualifiedName(objectQN))
+            if (fieldTypeSecondary != null) {
+                fieldBuilder.apiFieldTypeSecondary(fieldTypeSecondary)
+            }
+            if (isObjectRef) {
+                fieldBuilder.apiIsObjectReference(true)
+                val refQN = objectQNs[refSchemaName]
+                if (refQN != null) {
+                    fieldBuilder.apiObjectQualifiedName(refQN)
+                }
+            }
+            fieldBatch.add(fieldBuilder.build())
+        }
+        return objectQN
+    }
+
+    /**
+     * Sanitize a path URL for use in synthetic schema names.
+     */
+    private fun sanitizePath(pathUrl: String): String =
+        pathUrl
+            .replace("/", "_")
+            .replace("{", "")
+            .replace("}", "")
+            .trimStart('_')
 
     /**
      * Extract the request body schema from an operation, preferring application/json.

--- a/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
+++ b/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
@@ -2,6 +2,9 @@
    Copyright 2023 Atlan Pte. Ltd. */
 import com.atlan.AtlanClient
 import com.atlan.exception.AtlanException
+import com.atlan.model.assets.APIField
+import com.atlan.model.assets.APIMethod
+import com.atlan.model.assets.APIObject
 import com.atlan.model.assets.APIPath
 import com.atlan.model.assets.APISpec
 import com.atlan.model.core.AssetMutationResponse
@@ -10,15 +13,19 @@ import com.atlan.model.enums.CustomMetadataHandling
 import com.atlan.pkg.PackageContext
 import com.atlan.pkg.Utils
 import com.atlan.util.AssetBatch
+import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
+import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.parser.OpenAPIV3Parser
 import java.nio.file.Paths
+import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.AtomicLong
 import kotlin.system.exitProcess
 
 object OpenAPISpecLoader {
     private val logger = Utils.getLogger(OpenAPISpecLoader.javaClass.name)
+    private val jsonMapper = ObjectMapper()
 
     /**
      * Actually run the loader, taking all settings from environment variables.
@@ -151,6 +158,7 @@ object OpenAPISpecLoader {
         spec: OpenAPISpecReader,
         batchSize: Int,
     ) {
+        // --- Step 1: Save the APISpec (unchanged from original) ---
         val toCreate =
             APISpec
                 .creator(spec.title, connectionQN)
@@ -186,46 +194,296 @@ object OpenAPISpecLoader {
             logger.error("Unable to save the APISpec.", e)
             exitProcess(5)
         }
+
+        // --- Step 2: Create APIObjects and APIFields from components/schemas ---
+        val objectQNs = mutableMapOf<String, String>() // schemaName -> qualifiedName
+        val schemas = spec.schemas
+        if (!schemas.isNullOrEmpty()) {
+            logger.info { "Creating APIObjects for ${schemas.size} component schema(s)" }
+            AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { objectBatch ->
+                AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { fieldBatch ->
+                    try {
+                        for ((schemaName, schema) in schemas) {
+                            val objectQN = "$specQN/schemas/$schemaName"
+                            objectQNs[schemaName] = objectQN
+                            val properties = schema.properties ?: emptyMap()
+                            val apiObject = APIObject._internal()
+                                .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                                .qualifiedName(objectQN)
+                                .name(schemaName)
+                                .connectionQualifiedName(connectionQN)
+                                .apiSpecQualifiedName(specQN)
+                                .apiSpecName(spec.title)
+                                .apiSpecType(spec.openAPIVersion)
+                                .apiFieldCount(properties.size.toLong())
+                                .build()
+                            objectBatch.add(apiObject)
+                        }
+                        objectBatch.flush()
+
+                        // Second pass: create APIFields (after all APIObjects exist)
+                        for ((schemaName, schema) in schemas) {
+                            val objectQN = objectQNs[schemaName]!!
+                            val properties = schema.properties ?: emptyMap()
+                            for ((fieldName, fieldSchema) in properties) {
+                                val fieldQN = "$objectQN/$fieldName"
+                                val refSchemaName = extractRefSchemaName(fieldSchema)
+                                val isObjectRef = refSchemaName != null
+                                val fieldType = resolveFieldType(fieldSchema)
+                                val fieldTypeSecondary = resolveFieldTypeSecondary(fieldSchema)
+                                val fieldBuilder = APIField._internal()
+                                    .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                                    .qualifiedName(fieldQN)
+                                    .name(fieldName)
+                                    .connectionQualifiedName(connectionQN)
+                                    .apiSpecQualifiedName(specQN)
+                                    .apiSpecName(spec.title)
+                                    .apiSpecType(spec.openAPIVersion)
+                                    .apiFieldType(fieldType)
+                                    .apiObject(APIObject.refByQualifiedName(objectQN))
+                                if (fieldTypeSecondary != null) {
+                                    fieldBuilder.apiFieldTypeSecondary(fieldTypeSecondary)
+                                }
+                                if (isObjectRef) {
+                                    fieldBuilder.apiIsObjectReference(true)
+                                    val refQN = objectQNs[refSchemaName]
+                                    if (refQN != null) {
+                                        fieldBuilder.apiObjectQualifiedName(refQN)
+                                    }
+                                }
+                                fieldBatch.add(fieldBuilder.build())
+                            }
+                        }
+                        fieldBatch.flush()
+                    } catch (e: AtlanException) {
+                        logger.error("Unable to bulk-save API objects/fields.", e)
+                    }
+                }
+            }
+            logger.info { "Created ${objectQNs.size} APIObject(s) with their APIField children" }
+        }
+
+        // --- Step 3: Create APIPaths (unchanged) and APIMethod per operation ---
         val totalCount = spec.paths?.size!!.toLong()
         if (totalCount > 0) {
             logger.info { "Creating an APIPath for each path defined within the spec (total: $totalCount)" }
-            AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { batch ->
-                try {
-                    val assetCount = AtomicLong(0)
-                    for (apiPath in spec.paths.entries) {
-                        val pathUrl = apiPath.key
-                        val pathDetails = apiPath.value
-                        val operations = mutableListOf<String>()
-                        val desc = StringBuilder()
-                        desc.append("| Method | Summary|\n|---|---|\n")
-                        addOperationDetails(pathDetails.get, "GET", operations, desc)
-                        addOperationDetails(pathDetails.post, "POST", operations, desc)
-                        addOperationDetails(pathDetails.put, "PUT", operations, desc)
-                        addOperationDetails(pathDetails.patch, "PATCH", operations, desc)
-                        addOperationDetails(pathDetails.delete, "DELETE", operations, desc)
-                        val path =
-                            APIPath
-                                .creator(pathUrl, specQN)
-                                .description(desc.toString())
-                                .apiPathRawURI(pathUrl)
-                                .apiPathSummary(pathDetails.summary)
-                                .apiPathAvailableOperations(operations)
-                                .apiPathIsTemplated(pathUrl.contains("{") && pathUrl.contains("}"))
-                                .build()
-                        batch.add(path)
+            AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { pathBatch ->
+                AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { methodBatch ->
+                    try {
+                        val assetCount = AtomicLong(0)
+                        for (apiPath in spec.paths.entries) {
+                            val pathUrl = apiPath.key
+                            val pathDetails = apiPath.value
+
+                            // --- APIPath creation (unchanged from original) ---
+                            val operations = mutableListOf<String>()
+                            val desc = StringBuilder()
+                            desc.append("| Method | Summary|\n|---|---|\n")
+                            addOperationDetails(pathDetails.get, "GET", operations, desc)
+                            addOperationDetails(pathDetails.post, "POST", operations, desc)
+                            addOperationDetails(pathDetails.put, "PUT", operations, desc)
+                            addOperationDetails(pathDetails.patch, "PATCH", operations, desc)
+                            addOperationDetails(pathDetails.delete, "DELETE", operations, desc)
+                            val path =
+                                APIPath
+                                    .creator(pathUrl, specQN)
+                                    .description(desc.toString())
+                                    .apiPathRawURI(pathUrl)
+                                    .apiPathSummary(pathDetails.summary)
+                                    .apiPathAvailableOperations(operations)
+                                    .apiPathIsTemplated(pathUrl.contains("{") && pathUrl.contains("}"))
+                                    .build()
+                            pathBatch.add(path)
+                            val pathQN = path.qualifiedName
+
+                            // --- APIMethod creation per operation ---
+                            createMethodIfPresent(pathDetails.get, "GET", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
+                            createMethodIfPresent(pathDetails.post, "POST", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
+                            createMethodIfPresent(pathDetails.put, "PUT", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
+                            createMethodIfPresent(pathDetails.patch, "PATCH", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
+                            createMethodIfPresent(pathDetails.delete, "DELETE", pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch)
+
+                            Utils.logProgress(assetCount, totalCount, logger, batchSize)
+                        }
+                        pathBatch.flush()
+                        methodBatch.flush()
                         Utils.logProgress(assetCount, totalCount, logger, batchSize)
+                    } catch (e: AtlanException) {
+                        logger.error("Unable to bulk-save API paths/methods.", e)
                     }
-                    batch.flush()
-                    Utils.logProgress(assetCount, totalCount, logger, batchSize)
-                } catch (e: AtlanException) {
-                    logger.error("Unable to bulk-save API paths.", e)
                 }
             }
         }
     }
 
     /**
+     * Create an APIMethod asset for a single HTTP operation on a path, if the operation exists.
+     *
+     * @param operation the Swagger operation (may be null if this HTTP method is not defined on the path)
+     * @param httpMethod the HTTP method name (GET, POST, PUT, PATCH, DELETE)
+     * @param pathQN qualified name of the parent APIPath
+     * @param pathUrl the raw path URL (e.g., "/pet/{petId}")
+     * @param specQN qualified name of the parent APISpec
+     * @param connectionQN qualified name of the connection
+     * @param spec the OpenAPISpecReader for spec-level metadata
+     * @param objectQNs map of schema name to APIObject qualified name
+     * @param batch the AssetBatch to add the method to
+     */
+    private fun createMethodIfPresent(
+        operation: Operation?,
+        httpMethod: String,
+        pathQN: String,
+        pathUrl: String,
+        specQN: String,
+        connectionQN: String,
+        spec: OpenAPISpecReader,
+        objectQNs: Map<String, String>,
+        batch: AssetBatch,
+    ) {
+        if (operation == null) return
+
+        val methodName = "$httpMethod $pathUrl"
+        val methodQN = "$pathQN/$httpMethod"
+
+        val methodBuilder = APIMethod._internal()
+            .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+            .qualifiedName(methodQN)
+            .name(methodName)
+            .connectionQualifiedName(connectionQN)
+            .apiSpecQualifiedName(specQN)
+            .apiSpecName(spec.title)
+            .apiSpecType(spec.openAPIVersion)
+            .description(operation.summary ?: operation.description ?: "")
+            .apiPath(APIPath.refByQualifiedName(pathQN))
+
+        // Request body blob + schema relationship
+        val requestSchema = extractRequestSchema(operation)
+        if (requestSchema != null) {
+            methodBuilder.apiMethodRequest(serializeSchema(requestSchema))
+            val requestRefName = extractRefSchemaName(requestSchema)
+            if (requestRefName != null) {
+                val requestObjectQN = objectQNs[requestRefName]
+                if (requestObjectQN != null) {
+                    methodBuilder.apiMethodRequestSchema(APIObject.refByQualifiedName(requestObjectQN))
+                }
+            }
+        }
+
+        // Response bodies: blob for primary response + schema relationships for all
+        val responseCodes = mutableMapOf<String, String>()
+        val responseSchemas = mutableListOf<String>() // QNs for relationship set
+        var primaryResponseBlob: String? = null
+        if (operation.responses != null) {
+            for ((statusCode, apiResponse) in operation.responses) {
+                val responseSchema = extractResponseSchema(apiResponse)
+                if (responseSchema != null) {
+                    // Use the first success response (2xx) as the primary blob
+                    if (primaryResponseBlob == null && statusCode.startsWith("2")) {
+                        primaryResponseBlob = serializeSchema(responseSchema)
+                    }
+                    val refName = extractRefSchemaName(responseSchema)
+                    if (refName != null) {
+                        val responseObjectQN = objectQNs[refName]
+                        if (responseObjectQN != null) {
+                            responseCodes[statusCode] = responseObjectQN
+                            responseSchemas.add(responseObjectQN)
+                        }
+                    } else {
+                        // Inline schema: create a synthetic APIObject name for the response codes map
+                        val inlineName = "${httpMethod}_${pathUrl.replace("/", "_").replace("{", "").replace("}", "")}_${statusCode}"
+                        responseCodes[statusCode] = inlineName
+                    }
+                }
+            }
+        }
+        if (primaryResponseBlob != null) {
+            methodBuilder.apiMethodResponse(primaryResponseBlob)
+        }
+        if (responseCodes.isNotEmpty()) {
+            methodBuilder.apiMethodResponseCodes(responseCodes)
+        }
+        for (responseQN in responseSchemas) {
+            methodBuilder.apiMethodResponseSchema(APIObject.refByQualifiedName(responseQN))
+        }
+
+        batch.add(methodBuilder.build())
+    }
+
+    /**
+     * Extract the request body schema from an operation, preferring application/json.
+     */
+    private fun extractRequestSchema(operation: Operation): Schema<*>? {
+        val content = operation.requestBody?.content ?: return null
+        return content["application/json"]?.schema
+            ?: content["application/xml"]?.schema
+            ?: content.values.firstOrNull()?.schema
+    }
+
+    /**
+     * Extract the response body schema from an API response, preferring application/json.
+     */
+    private fun extractResponseSchema(response: io.swagger.v3.oas.models.responses.ApiResponse): Schema<*>? {
+        val content = response.content ?: return null
+        return content["application/json"]?.schema
+            ?: content["application/xml"]?.schema
+            ?: content.values.firstOrNull()?.schema
+    }
+
+    /**
+     * Extract the schema name from a $ref string like "#/components/schemas/Pet".
+     * Returns null if the schema is inline (no $ref).
+     */
+    private fun extractRefSchemaName(schema: Schema<*>): String? {
+        val ref = schema.`$ref`
+        if (ref != null && ref.startsWith("#/components/schemas/")) {
+            return ref.removePrefix("#/components/schemas/")
+        }
+        // Check if this is an array of $ref items
+        if (schema.type == "array" && schema.items?.`$ref` != null) {
+            val itemRef = schema.items.`$ref`
+            if (itemRef.startsWith("#/components/schemas/")) {
+                return itemRef.removePrefix("#/components/schemas/")
+            }
+        }
+        return null
+    }
+
+    /**
+     * Resolve the primary type of a field from its schema.
+     */
+    private fun resolveFieldType(schema: Schema<*>): String {
+        // If it's a $ref, resolve to "object"
+        if (schema.`$ref` != null) return "object"
+        val type = schema.type ?: "object"
+        val format = schema.format
+        return if (format != null) "$type/$format" else type
+    }
+
+    /**
+     * Resolve the secondary type of a field (e.g., for array types, the secondary is "array").
+     */
+    private fun resolveFieldTypeSecondary(schema: Schema<*>): String? {
+        if (schema.type == "array") {
+            val itemType = schema.items?.type ?: if (schema.items?.`$ref` != null) "object" else "string"
+            return "array"
+        }
+        return null
+    }
+
+    /**
+     * Serialize a schema to a JSON string for the blob attributes.
+     */
+    private fun serializeSchema(schema: Schema<*>): String {
+        return try {
+            jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(schema)
+        } catch (e: Exception) {
+            schema.toString()
+        }
+    }
+
+    /**
      * Add the details of the provided operation to the details captured for the APIPath.
+     * (Unchanged from original — preserved for backward compatibility.)
      *
      * @param operation the operation to include (if non-null) as one that exists for the path
      * @param name the name of the operation
@@ -261,6 +519,7 @@ object OpenAPISpecLoader {
         val sourceURL: String
         val openAPIVersion: String
         val paths: io.swagger.v3.oas.models.Paths?
+        val schemas: Map<String, Schema<*>>?
         val title: String
         val description: String
         val termsOfServiceURL: String
@@ -278,6 +537,7 @@ object OpenAPISpecLoader {
             sourceURL = url
             openAPIVersion = spec.openapi
             paths = spec.paths
+            schemas = spec.components?.schemas
             title = spec.info?.title ?: ""
             description = spec.info?.description ?: ""
             termsOfServiceURL = spec.info?.termsOfService ?: ""

--- a/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
+++ b/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
@@ -207,16 +207,18 @@ object OpenAPISpecLoader {
                             val objectQN = "$specQN/schemas/$schemaName"
                             objectQNs[schemaName] = objectQN
                             val properties = schema.properties ?: emptyMap()
-                            val apiObject = APIObject._internal()
-                                .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
-                                .qualifiedName(objectQN)
-                                .name(schemaName)
-                                .connectionQualifiedName(connectionQN)
-                                .apiSpecQualifiedName(specQN)
-                                .apiSpecName(spec.title)
-                                .apiSpecType(spec.openAPIVersion)
-                                .apiFieldCount(properties.size.toLong())
-                                .build()
+                            val apiObject =
+                                APIObject
+                                    ._internal()
+                                    .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                                    .qualifiedName(objectQN)
+                                    .name(schemaName)
+                                    .connectionQualifiedName(connectionQN)
+                                    .apiSpecQualifiedName(specQN)
+                                    .apiSpecName(spec.title)
+                                    .apiSpecType(spec.openAPIVersion)
+                                    .apiFieldCount(properties.size.toLong())
+                                    .build()
                             objectBatch.add(apiObject)
                         }
                         objectBatch.flush()
@@ -231,16 +233,18 @@ object OpenAPISpecLoader {
                                 val isObjectRef = refSchemaName != null
                                 val fieldType = resolveFieldType(fieldSchema)
                                 val fieldTypeSecondary = resolveFieldTypeSecondary(fieldSchema)
-                                val fieldBuilder = APIField._internal()
-                                    .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
-                                    .qualifiedName(fieldQN)
-                                    .name(fieldName)
-                                    .connectionQualifiedName(connectionQN)
-                                    .apiSpecQualifiedName(specQN)
-                                    .apiSpecName(spec.title)
-                                    .apiSpecType(spec.openAPIVersion)
-                                    .apiFieldType(fieldType)
-                                    .apiObject(APIObject.refByQualifiedName(objectQN))
+                                val fieldBuilder =
+                                    APIField
+                                        ._internal()
+                                        .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                                        .qualifiedName(fieldQN)
+                                        .name(fieldName)
+                                        .connectionQualifiedName(connectionQN)
+                                        .apiSpecQualifiedName(specQN)
+                                        .apiSpecName(spec.title)
+                                        .apiSpecType(spec.openAPIVersion)
+                                        .apiFieldType(fieldType)
+                                        .apiObject(APIObject.refByQualifiedName(objectQN))
                                 if (fieldTypeSecondary != null) {
                                     fieldBuilder.apiFieldTypeSecondary(fieldTypeSecondary)
                                 }
@@ -345,16 +349,18 @@ object OpenAPISpecLoader {
         val methodName = "$httpMethod $pathUrl"
         val methodQN = "$pathQN/$httpMethod"
 
-        val methodBuilder = APIMethod._internal()
-            .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
-            .qualifiedName(methodQN)
-            .name(methodName)
-            .connectionQualifiedName(connectionQN)
-            .apiSpecQualifiedName(specQN)
-            .apiSpecName(spec.title)
-            .apiSpecType(spec.openAPIVersion)
-            .description(operation.summary ?: operation.description ?: "")
-            .apiPath(APIPath.refByQualifiedName(pathQN))
+        val methodBuilder =
+            APIMethod
+                ._internal()
+                .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                .qualifiedName(methodQN)
+                .name(methodName)
+                .connectionQualifiedName(connectionQN)
+                .apiSpecQualifiedName(specQN)
+                .apiSpecName(spec.title)
+                .apiSpecType(spec.openAPIVersion)
+                .description(operation.summary ?: operation.description ?: "")
+                .apiPath(APIPath.refByQualifiedName(pathQN))
 
         // Request body blob + schema relationship
         val requestSchema = extractRequestSchema(operation)
@@ -390,7 +396,7 @@ object OpenAPISpecLoader {
                         }
                     } else {
                         // Inline schema: create a synthetic APIObject name for the response codes map
-                        val inlineName = "${httpMethod}_${pathUrl.replace("/", "_").replace("{", "").replace("}", "")}_${statusCode}"
+                        val inlineName = "${httpMethod}_${pathUrl.replace("/", "_").replace("{", "").replace("}", "")}_$statusCode"
                         responseCodes[statusCode] = inlineName
                     }
                 }
@@ -473,13 +479,12 @@ object OpenAPISpecLoader {
     /**
      * Serialize a schema to a JSON string for the blob attributes.
      */
-    private fun serializeSchema(schema: Schema<*>): String {
-        return try {
+    private fun serializeSchema(schema: Schema<*>): String =
+        try {
             jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(schema)
         } catch (e: Exception) {
             schema.toString()
         }
-    }
 
     /**
      * Add the details of the provided operation to the details captured for the APIPath.

--- a/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
+++ b/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
@@ -67,7 +67,7 @@ object OpenAPISpecLoader {
                 exitProcess(4)
             }
 
-            val objectMode = ctx.config.objectCreationMode.ifBlank { MODE_PHYSICAL }
+            val objectMode = ctx.config.objectCreationMode?.ifBlank { MODE_PHYSICAL } ?: MODE_PHYSICAL
             logger.info { "Object creation mode: $objectMode" }
 
             val sourceFiles =

--- a/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
+++ b/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoader.kt
@@ -13,11 +13,16 @@ import com.atlan.model.enums.CustomMetadataHandling
 import com.atlan.pkg.PackageContext
 import com.atlan.pkg.Utils
 import com.atlan.util.AssetBatch
+import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.swagger.v3.oas.models.OpenAPI
 import io.swagger.v3.oas.models.Operation
 import io.swagger.v3.oas.models.media.Schema
 import io.swagger.v3.parser.OpenAPIV3Parser
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.nio.file.Files
 import java.nio.file.Paths
 import java.util.concurrent.ThreadLocalRandom
 import java.util.concurrent.atomic.AtomicLong
@@ -25,7 +30,15 @@ import kotlin.system.exitProcess
 
 object OpenAPISpecLoader {
     private val logger = Utils.getLogger(OpenAPISpecLoader.javaClass.name)
-    private val jsonMapper = ObjectMapper()
+    private val jsonMapper = ObjectMapper().apply {
+        setSerializationInclusion(JsonInclude.Include.NON_NULL)
+    }
+
+    /** Object creation mode: create physical per-method instances (default). */
+    const val MODE_PHYSICAL = "PHYSICAL"
+
+    /** Object creation mode: skip APIObject/APIField creation entirely (bodies-only). */
+    const val MODE_NONE = "NONE"
 
     /**
      * Actually run the loader, taking all settings from environment variables.
@@ -53,6 +66,9 @@ object OpenAPISpecLoader {
                 logger.error { "Missing required parameter - you must provide BOTH a connection name and specification URL." }
                 exitProcess(4)
             }
+
+            val objectMode = ctx.config.objectCreationMode.ifBlank { MODE_PHYSICAL }
+            logger.info { "Object creation mode: $objectMode" }
 
             val sourceFiles =
                 when (ctx.config.importType) {
@@ -95,7 +111,7 @@ object OpenAPISpecLoader {
                     }
                 }
             for (sourceFile in sourceFiles) {
-                processFile(ctx, connectionQN, sourceFile, batchSize, outputDirectory)
+                processFile(ctx, connectionQN, sourceFile, batchSize, outputDirectory, objectMode)
             }
         }
     }
@@ -106,6 +122,7 @@ object OpenAPISpecLoader {
         sourceFile: String,
         batchSize: Int,
         outputDirectory: String,
+        objectMode: String,
     ) {
         val fileType =
             Paths
@@ -116,18 +133,24 @@ object OpenAPISpecLoader {
         when (fileType) {
             "json", "yaml", "yml" -> {
                 logger.info { "Loading OpenAPI specification from $sourceFile into: $connectionQN" }
-                loadOpenAPISpec(ctx.client, connectionQN, OpenAPISpecReader(sourceFile), batchSize)
+                loadOpenAPISpec(ctx.client, connectionQN, OpenAPISpecReader(sourceFile), batchSize, objectMode)
             }
 
             "zip" -> {
                 logger.info { "Extracting and processing ZIP file: $sourceFile" }
                 val extractedFiles = Utils.unzipFiles(sourceFile, outputDirectory)
-                processExtractedFiles(ctx, connectionQN, extractedFiles, batchSize)
+                processExtractedFiles(ctx, connectionQN, extractedFiles, batchSize, objectMode)
             }
 
             else -> {
-                logger.error { "Invalid file type. Please provide a JSON, YAML or ZIP file." }
-                exitProcess(1)
+                // No extension — might be a URL
+                if (sourceFile.startsWith("http://") || sourceFile.startsWith("https://")) {
+                    logger.info { "Loading OpenAPI specification from URL $sourceFile into: $connectionQN" }
+                    loadOpenAPISpec(ctx.client, connectionQN, OpenAPISpecReader(sourceFile), batchSize, objectMode)
+                } else {
+                    logger.error { "Invalid file type. Please provide a JSON, YAML or ZIP file." }
+                    exitProcess(1)
+                }
             }
         }
     }
@@ -137,10 +160,11 @@ object OpenAPISpecLoader {
         connectionQN: String,
         extractedFiles: List<String>,
         batchSize: Int,
+        objectMode: String,
     ) {
         extractedFiles.filter { it.endsWith(".json") || it.endsWith(".yaml") || it.endsWith(".yml") }.forEach { file ->
             logger.info { "Loading OpenAPI specification from extracted file: $file" }
-            loadOpenAPISpec(ctx.client, connectionQN, OpenAPISpecReader(file), batchSize)
+            loadOpenAPISpec(ctx.client, connectionQN, OpenAPISpecReader(file), batchSize, objectMode)
         }
     }
 
@@ -151,15 +175,17 @@ object OpenAPISpecLoader {
      * @param connectionQN qualifiedName of the connection in which to create the assets
      * @param spec object for reading from the OpenAPI spec itself
      * @param batchSize maximum number of assets to save per API request
+     * @param objectMode how to create APIObject/APIField assets: PHYSICAL (per-body instances) or NONE (skip)
      */
     fun loadOpenAPISpec(
         client: AtlanClient,
         connectionQN: String,
         spec: OpenAPISpecReader,
         batchSize: Int,
+        objectMode: String = MODE_PHYSICAL,
     ) {
-        // --- Step 1: Save the APISpec (unchanged from original) ---
-        val toCreate =
+        // --- Step 1: Save the APISpec with raw content ---
+        val specBuilder =
             APISpec
                 .creator(spec.title, connectionQN)
                 .sourceURL(spec.sourceURL)
@@ -174,7 +200,10 @@ object OpenAPISpecLoader {
                 .apiSpecVersion(spec.version)
                 .apiExternalDoc("url", spec.externalDocsURL)
                 .apiExternalDoc("description", spec.externalDocsDescription)
-                .build()
+        if (spec.rawContent.isNotEmpty()) {
+            specBuilder.apiSpecRawContent(spec.rawContent)
+        }
+        val toCreate = specBuilder.build()
         val specQN = toCreate.qualifiedName
         logger.info { "Saving APISpec: $specQN" }
         try {
@@ -195,93 +224,28 @@ object OpenAPISpecLoader {
             exitProcess(5)
         }
 
-        // --- Step 2: Create APIObjects and APIFields from components/schemas ---
-        val objectQNs = mutableMapOf<String, String>() // schemaName -> qualifiedName
-        val schemas = spec.schemas
-        if (!schemas.isNullOrEmpty()) {
-            logger.info { "Creating APIObjects for ${schemas.size} component schema(s)" }
-            AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { objectBatch ->
-                AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { fieldBatch ->
-                    try {
-                        for ((schemaName, schema) in schemas) {
-                            val objectQN = "$specQN/schemas/$schemaName"
-                            objectQNs[schemaName] = objectQN
-                            val properties = schema.properties ?: emptyMap()
-                            val apiObject =
-                                APIObject
-                                    ._internal()
-                                    .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
-                                    .qualifiedName(objectQN)
-                                    .name(schemaName)
-                                    .connectionQualifiedName(connectionQN)
-                                    .apiSpecQualifiedName(specQN)
-                                    .apiSpecName(spec.title)
-                                    .apiSpecType(spec.openAPIVersion)
-                                    .apiFieldCount(properties.size.toLong())
-                                    .build()
-                            objectBatch.add(apiObject)
-                        }
-                        objectBatch.flush()
+        // --- Step 2: Create APIPaths and APIMethod per operation ---
+        // In PHYSICAL mode, APIObjects/APIFields are created per-body during method processing.
+        // In NONE mode, only paths and methods are created (bodies-only).
+        // Collect method-to-object relationship mappings (SDK attribute names don't match Atlas
+        // typedef end names, so we create these via the REST API after entity creation)
+        val methodRequestSchemaMap = mutableMapOf<String, String>()   // methodQN → requestObjectQN
+        val methodResponseSchemaMap = mutableMapOf<String, MutableList<String>>() // methodQN → [responseObjectQNs]
 
-                        // Second pass: create APIFields (after all APIObjects exist)
-                        for ((schemaName, schema) in schemas) {
-                            val objectQN = objectQNs[schemaName]!!
-                            val properties = schema.properties ?: emptyMap()
-                            for ((fieldName, fieldSchema) in properties) {
-                                val fieldQN = "$objectQN/$fieldName"
-                                val refSchemaName = extractRefSchemaName(fieldSchema)
-                                val isObjectRef = refSchemaName != null
-                                val fieldType = resolveFieldType(fieldSchema)
-                                val fieldTypeSecondary = resolveFieldTypeSecondary(fieldSchema)
-                                val fieldBuilder =
-                                    APIField
-                                        ._internal()
-                                        .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
-                                        .qualifiedName(fieldQN)
-                                        .name(fieldName)
-                                        .connectionQualifiedName(connectionQN)
-                                        .apiSpecQualifiedName(specQN)
-                                        .apiSpecName(spec.title)
-                                        .apiSpecType(spec.openAPIVersion)
-                                        .apiFieldType(fieldType)
-                                        .apiObject(APIObject.refByQualifiedName(objectQN))
-                                if (fieldTypeSecondary != null) {
-                                    fieldBuilder.apiFieldTypeSecondary(fieldTypeSecondary)
-                                }
-                                if (isObjectRef) {
-                                    fieldBuilder.apiIsObjectReference(true)
-                                    val refQN = objectQNs[refSchemaName]
-                                    if (refQN != null) {
-                                        fieldBuilder.apiObjectQualifiedName(refQN)
-                                    }
-                                }
-                                fieldBatch.add(fieldBuilder.build())
-                            }
-                        }
-                        fieldBatch.flush()
-                    } catch (e: AtlanException) {
-                        logger.error("Unable to bulk-save API objects/fields.", e)
-                    }
-                }
-            }
-            logger.info { "Created ${objectQNs.size} APIObject(s) with their APIField children" }
-        }
-
-        // --- Step 3: Create APIPaths (unchanged) and APIMethod per operation ---
         val totalCount = spec.paths?.size!!.toLong()
         if (totalCount > 0) {
             logger.info { "Creating an APIPath for each path defined within the spec (total: $totalCount)" }
             AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { pathBatch ->
                 AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { methodBatch ->
-                    AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { inlineObjectBatch ->
-                        AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { inlineFieldBatch ->
+                    AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { objectBatch ->
+                        AssetBatch(client, batchSize, AtlanTagHandling.IGNORE, CustomMetadataHandling.MERGE, true).use { fieldBatch ->
                             try {
                                 val assetCount = AtomicLong(0)
                                 for (apiPath in spec.paths.entries) {
                                     val pathUrl = apiPath.key
                                     val pathDetails = apiPath.value
 
-                                    // --- APIPath creation (unchanged from original) ---
+                                    // --- APIPath creation ---
                                     val operations = mutableListOf<String>()
                                     val desc = StringBuilder()
                                     desc.append("| Method | Summary|\n|---|---|\n")
@@ -290,9 +254,19 @@ object OpenAPISpecLoader {
                                     addOperationDetails(pathDetails.put, "PUT", operations, desc)
                                     addOperationDetails(pathDetails.patch, "PATCH", operations, desc)
                                     addOperationDetails(pathDetails.delete, "DELETE", operations, desc)
+                                    // Encode path slashes as ~ so each hierarchy level = 1 QN segment
+                                    val encodedPath = pathUrl.replace("/", "~")
+                                    val pathQN = "$specQN/$encodedPath"
                                     val path =
                                         APIPath
-                                            .creator(pathUrl, specQN)
+                                            ._internal()
+                                            .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                                            .qualifiedName(pathQN)
+                                            .name(pathUrl)
+                                            .connectionQualifiedName(connectionQN)
+                                            .apiSpec(APISpec.refByQualifiedName(specQN))
+                                            .apiSpecQualifiedName(specQN)
+                                            .apiPathQualifiedName(pathQN)
                                             .description(desc.toString())
                                             .apiPathRawURI(pathUrl)
                                             .apiPathSummary(pathDetails.summary)
@@ -300,19 +274,18 @@ object OpenAPISpecLoader {
                                             .apiPathIsTemplated(pathUrl.contains("{") && pathUrl.contains("}"))
                                             .build()
                                     pathBatch.add(path)
-                                    val pathQN = path.qualifiedName
 
-                                    // --- APIMethod creation per operation (with inline schema support) ---
+                                    // --- APIMethod creation per operation ---
                                     val methods = listOf("GET" to pathDetails.get, "POST" to pathDetails.post, "PUT" to pathDetails.put, "PATCH" to pathDetails.patch, "DELETE" to pathDetails.delete)
                                     for ((httpMethod, op) in methods) {
-                                        createMethodIfPresent(op, httpMethod, pathQN, pathUrl, specQN, connectionQN, spec, objectQNs, methodBatch, inlineObjectBatch, inlineFieldBatch)
+                                        createMethodIfPresent(op, httpMethod, pathQN, pathUrl, specQN, connectionQN, spec, objectMode, methodBatch, objectBatch, fieldBatch, methodRequestSchemaMap, methodResponseSchemaMap)
                                     }
 
                                     Utils.logProgress(assetCount, totalCount, logger, batchSize)
                                 }
                                 pathBatch.flush()
-                                inlineObjectBatch.flush()
-                                inlineFieldBatch.flush()
+                                objectBatch.flush()
+                                fieldBatch.flush()
                                 methodBatch.flush()
                                 Utils.logProgress(assetCount, totalCount, logger, batchSize)
                             } catch (e: AtlanException) {
@@ -323,20 +296,40 @@ object OpenAPISpecLoader {
                 }
             }
         }
+
+        // --- Step 3: Create method↔object relationships via REST API ---
+        // The SDK's relationship attribute names for method-object peer relationships are
+        // swapped relative to the Atlas typedef end names, so we create these relationships
+        // directly via the Atlas relationship REST API using qualified name references.
+        if (objectMode == MODE_PHYSICAL) {
+            val baseUrl = client.baseUrl
+            val apiToken = System.getenv("ATLAN_API_KEY") ?: ""
+            logger.info { "Creating method↔object relationships (${methodRequestSchemaMap.size} request, ${methodResponseSchemaMap.values.sumOf { it.size }} response)..." }
+
+            for ((methodQN, objectQN) in methodRequestSchemaMap) {
+                createRelationshipViaApi(
+                    baseUrl, apiToken,
+                    "api_method_request_schema_api_methods_requesting_this",
+                    methodQN, "APIMethod", objectQN, "APIObject",
+                )
+            }
+            for ((methodQN, objectQNs) in methodResponseSchemaMap) {
+                for (objectQN in objectQNs) {
+                    createRelationshipViaApi(
+                        baseUrl, apiToken,
+                        "api_method_response_schemas_api_methods_responding_with_this",
+                        methodQN, "APIMethod", objectQN, "APIObject",
+                    )
+                }
+            }
+            logger.info { "Relationships created." }
+        }
     }
 
     /**
      * Create an APIMethod asset for a single HTTP operation on a path, if the operation exists.
-     *
-     * @param operation the Swagger operation (may be null if this HTTP method is not defined on the path)
-     * @param httpMethod the HTTP method name (GET, POST, PUT, PATCH, DELETE)
-     * @param pathQN qualified name of the parent APIPath
-     * @param pathUrl the raw path URL (e.g., "/pet/{petId}")
-     * @param specQN qualified name of the parent APISpec
-     * @param connectionQN qualified name of the connection
-     * @param spec the OpenAPISpecReader for spec-level metadata
-     * @param objectQNs map of schema name to APIObject qualified name
-     * @param batch the AssetBatch to add the method to
+     * In PHYSICAL mode, also creates contextualized APIObject/APIField instances for each body.
+     * In NONE mode, only sets the JSON blob attributes on the method (no APIObject/APIField).
      */
     private fun createMethodIfPresent(
         operation: Operation?,
@@ -346,15 +339,18 @@ object OpenAPISpecLoader {
         specQN: String,
         connectionQN: String,
         spec: OpenAPISpecReader,
-        objectQNs: MutableMap<String, String>,
+        objectMode: String,
         methodBatch: AssetBatch,
         objectBatch: AssetBatch,
         fieldBatch: AssetBatch,
+        methodRequestSchemaMap: MutableMap<String, String>,
+        methodResponseSchemaMap: MutableMap<String, MutableList<String>>,
     ) {
         if (operation == null) return
 
         val methodName = "$httpMethod $pathUrl"
         val methodQN = "$pathQN/$httpMethod"
+        val methodContext = "${httpMethod}_${sanitizePath(pathUrl)}"
 
         val methodBuilder =
             APIMethod
@@ -364,127 +360,190 @@ object OpenAPISpecLoader {
                 .name(methodName)
                 .connectionQualifiedName(connectionQN)
                 .apiSpecQualifiedName(specQN)
+                .apiPathQualifiedName(pathQN)
+                .apiMethodQualifiedName(methodQN)
                 .apiSpecName(spec.title)
                 .apiSpecType(spec.openAPIVersion)
                 .description(operation.summary ?: operation.description ?: "")
                 .apiPath(APIPath.refByQualifiedName(pathQN))
 
-        // Request body blob + schema relationship
+        // --- Request body ---
+        val pathQNForHierarchy = pathQN
         val requestSchema = extractRequestSchema(operation)
         if (requestSchema != null) {
-            methodBuilder.apiMethodRequest(serializeSchema(requestSchema))
-            val requestRefName = extractRefSchemaName(requestSchema)
-            if (requestRefName != null) {
-                val requestObjectQN = objectQNs[requestRefName]
-                if (requestObjectQN != null) {
-                    methodBuilder.apiMethodRequestSchema(APIObject.refByQualifiedName(requestObjectQN))
-                }
-            } else if (requestSchema.properties != null && requestSchema.properties.isNotEmpty()) {
-                // Inline request schema with properties — create synthetic APIObject + APIFields
-                val syntheticName = "${httpMethod}_${sanitizePath(pathUrl)}_Request"
-                val syntheticQN =
-                    createInlineSchemaObject(
-                        syntheticName,
-                        requestSchema,
-                        specQN,
-                        connectionQN,
-                        spec,
-                        objectQNs,
-                        objectBatch,
-                        fieldBatch,
+            val requestExample = generateExample(requestSchema, spec.schemas)
+            methodBuilder.apiMethodRequest(
+                if (requestExample != null) jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(requestExample)
+                else serializeSchema(requestSchema, spec.schemas)
+            )
+
+            if (objectMode == MODE_PHYSICAL) {
+                val resolvedSchema = resolveSchema(requestSchema, spec.schemas)
+                if (resolvedSchema != null && hasProperties(resolvedSchema)) {
+                    // Object schema with properties → full APIObject + child APIFields
+                    val schemaName = extractRefSchemaName(requestSchema) ?: "${methodContext}_Request"
+                    val physicalName = "${methodContext}/request/$schemaName"
+                    val physicalQN = createPhysicalSchemaObject(
+                        physicalName, "request", schemaName, resolvedSchema,
+                        specQN, connectionQN, pathQNForHierarchy, methodQN, "request",
+                        spec, objectBatch, fieldBatch, mutableSetOf(schemaName),
                     )
-                methodBuilder.apiMethodRequestSchema(APIObject.refByQualifiedName(syntheticQN))
+                    methodRequestSchemaMap[methodQN] = physicalQN
+                } else {
+                    // Primitive or unresolved schema → shell APIObject (no child fields)
+                    val schemaLabel = requestSchema.type ?: "inline"
+                    val physicalName = "${methodContext}/request/$schemaLabel"
+                    val objectQN = createShellResponseObject(
+                        physicalName, "request", "request",
+                        specQN, connectionQN, pathQNForHierarchy, methodQN,
+                        spec, objectBatch,
+                    )
+                    methodRequestSchemaMap[methodQN] = objectQN
+                }
             }
         }
 
-        // Response bodies: blob for primary response + schema relationships for all
+        // --- Response bodies ---
         val responseCodes = mutableMapOf<String, String>()
-        val responseSchemas = mutableListOf<String>() // QNs for relationship set
-        var primaryResponseBlob: String? = null
+        val responseSchemas = mutableListOf<String>()
+        val allResponseBlobs = mutableMapOf<String, Any>()
         if (operation.responses != null) {
             for ((statusCode, apiResponse) in operation.responses) {
+                val description = apiResponse.description ?: ""
                 val responseSchema = extractResponseSchema(apiResponse)
+                val bodyType = "response/$statusCode"
+                val bodyDisplayName = "response $statusCode"
+
                 if (responseSchema != null) {
-                    // Use the first success response (2xx) as the primary blob
-                    if (primaryResponseBlob == null && statusCode.startsWith("2")) {
-                        primaryResponseBlob = serializeSchema(responseSchema)
+                    val blobEntry = mutableMapOf<String, Any>()
+                    blobEntry["description"] = description
+                    val responseExample = generateExample(responseSchema, spec.schemas)
+                    if (responseExample != null) {
+                        blobEntry["example"] = responseExample
                     }
-                    val refName = extractRefSchemaName(responseSchema)
-                    if (refName != null) {
-                        val responseObjectQN = objectQNs[refName]
-                        if (responseObjectQN != null) {
-                            responseCodes[statusCode] = responseObjectQN
-                            responseSchemas.add(responseObjectQN)
-                        }
-                    } else if (responseSchema.properties != null && responseSchema.properties.isNotEmpty()) {
-                        // Inline response schema with properties — create synthetic APIObject + APIFields
-                        val syntheticName = "${httpMethod}_${sanitizePath(pathUrl)}_${statusCode}_Response"
-                        val syntheticQN =
-                            createInlineSchemaObject(
-                                syntheticName,
-                                responseSchema,
-                                specQN,
-                                connectionQN,
-                                spec,
-                                objectQNs,
-                                objectBatch,
-                                fieldBatch,
+
+                    if (objectMode == MODE_PHYSICAL) {
+                        val resolvedSchema = resolveSchema(responseSchema, spec.schemas)
+                        if (resolvedSchema != null && hasProperties(resolvedSchema)) {
+                            // Object schema with properties → full APIObject + child APIFields
+                            val schemaName = extractRefSchemaName(responseSchema) ?: "${methodContext}_${statusCode}_Response"
+                            val physicalName = "${methodContext}/response/${statusCode}/$schemaName"
+                            val physicalQN = createPhysicalSchemaObject(
+                                physicalName, bodyDisplayName, schemaName, resolvedSchema,
+                                specQN, connectionQN, pathQNForHierarchy, methodQN, bodyType,
+                                spec, objectBatch, fieldBatch, mutableSetOf(schemaName),
                             )
-                        responseCodes[statusCode] = syntheticQN
-                        responseSchemas.add(syntheticQN)
+                            responseCodes[statusCode] = physicalQN
+                            responseSchemas.add(physicalQN)
+                        } else {
+                            // Primitive or unresolved schema → shell APIObject (no child fields)
+                            val schemaLabel = responseSchema.type ?: "inline"
+                            val physicalName = "${methodContext}/response/${statusCode}/$schemaLabel"
+                            val objectQN = createShellResponseObject(
+                                physicalName, bodyDisplayName, bodyType,
+                                specQN, connectionQN, pathQNForHierarchy, methodQN,
+                                spec, objectBatch,
+                            )
+                            responseCodes[statusCode] = objectQN
+                            responseSchemas.add(objectQN)
+                        }
                     } else {
-                        // Inline primitive/array schema — record in response codes map only
-                        val inlineName = "${httpMethod}_${sanitizePath(pathUrl)}_$statusCode"
+                        // NONE mode — no objects, just record a label
+                        val inlineName = "${methodContext}_$statusCode"
                         responseCodes[statusCode] = inlineName
+                    }
+                    allResponseBlobs[statusCode] = blobEntry
+                } else {
+                    // No content block — description-only response
+                    allResponseBlobs[statusCode] = mapOf("description" to description)
+
+                    if (objectMode == MODE_PHYSICAL) {
+                        // Still create a shell APIObject so it appears in the hierarchy
+                        val physicalName = "${methodContext}/response/${statusCode}/no_content"
+                        val objectQN = createShellResponseObject(
+                            physicalName, bodyDisplayName, bodyType,
+                            specQN, connectionQN, pathQNForHierarchy, methodQN,
+                            spec, objectBatch,
+                        )
+                        responseCodes[statusCode] = objectQN
+                        responseSchemas.add(objectQN)
                     }
                 }
             }
         }
-        if (primaryResponseBlob != null) {
-            methodBuilder.apiMethodResponse(primaryResponseBlob)
+        if (allResponseBlobs.isNotEmpty()) {
+            methodBuilder.apiMethodResponse(jsonMapper.writeValueAsString(allResponseBlobs))
         }
         if (responseCodes.isNotEmpty()) {
             methodBuilder.apiMethodResponseCodes(responseCodes)
         }
-        for (responseQN in responseSchemas) {
-            methodBuilder.apiMethodResponseSchema(APIObject.refByQualifiedName(responseQN))
+        // Collect response schema relationships (created via REST API after batch flush)
+        if (responseSchemas.isNotEmpty()) {
+            methodResponseSchemaMap.getOrPut(methodQN) { mutableListOf() }.addAll(responseSchemas)
         }
 
         methodBatch.add(methodBuilder.build())
     }
 
     /**
-     * Create a synthetic APIObject (and its APIFields) for an inline schema that has properties.
-     * Returns the qualified name of the created APIObject.
+     * Create a physical (per-body) APIObject and its APIFields for a schema occurrence,
+     * recursing into nested $ref sub-objects. Names use xpath-style paths (e.g., "Pet/category/name").
+     *
+     * @param contextPath QN path fragment like "POST_pet/request/Pet" that makes this instance unique
+     * @param displayName xpath-style display name for the object (e.g., "Pet" or "Pet/category")
+     * @param rootSchemaName the top-level schema name, used as prefix for all child names
+     * @param schema the resolved schema with properties
+     * @param specQN qualified name of the parent APISpec
+     * @param connectionQN qualified name of the connection
+     * @param pathQN qualified name of the parent APIPath (for hierarchy filters)
+     * @param methodQN qualified name of the parent APIMethod (for hierarchy filters)
+     * @param bodyType body context: "request", "response/200", etc. (for body filter)
+     * @param spec the OpenAPISpecReader for spec-level metadata
+     * @param objectBatch the AssetBatch for APIObjects
+     * @param fieldBatch the AssetBatch for APIFields
+     * @param visitedSchemas set of schema names visited in the current recursion path (cycle detection)
+     * @return the qualified name of the created APIObject
      */
-    private fun createInlineSchemaObject(
-        syntheticName: String,
+    private fun createPhysicalSchemaObject(
+        contextPath: String,
+        displayName: String,
+        rootSchemaName: String,
         schema: Schema<*>,
         specQN: String,
         connectionQN: String,
+        pathQN: String,
+        methodQN: String,
+        bodyType: String,
         spec: OpenAPISpecReader,
-        objectQNs: MutableMap<String, String>,
         objectBatch: AssetBatch,
         fieldBatch: AssetBatch,
+        visitedSchemas: MutableSet<String>,
     ): String {
-        val objectQN = "$specQN/schemas/$syntheticName"
-        objectQNs[syntheticName] = objectQN
+        val objectQN = "$specQN/schemas/$contextPath"
         val properties = schema.properties ?: emptyMap()
         val apiObject =
             APIObject
                 ._internal()
                 .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
                 .qualifiedName(objectQN)
-                .name(syntheticName)
+                .name(displayName)
                 .connectionQualifiedName(connectionQN)
                 .apiSpecQualifiedName(specQN)
                 .apiSpecName(spec.title)
                 .apiSpecType(spec.openAPIVersion)
                 .apiFieldCount(properties.size.toLong())
+                .apiPathQualifiedName(pathQN)
+                .apiMethodQualifiedName(methodQN)
+                .apiBodyType(bodyType)
                 .build()
         objectBatch.add(apiObject)
+
         for ((fieldName, fieldSchema) in properties) {
-            val fieldQN = "$objectQN/$fieldName"
+            val isArray = fieldSchema.type == "array"
+            val arraySuffix = if (isArray) "[]" else ""
+            val fieldDisplayName = "$displayName/$fieldName$arraySuffix"
+            val fieldQN = "$objectQN/$fieldName$arraySuffix"
+
             val refSchemaName = extractRefSchemaName(fieldSchema)
             val isObjectRef = refSchemaName != null
             val fieldType = resolveFieldType(fieldSchema)
@@ -494,27 +553,112 @@ object OpenAPISpecLoader {
                     ._internal()
                     .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
                     .qualifiedName(fieldQN)
-                    .name(fieldName)
+                    .name(fieldDisplayName)
                     .connectionQualifiedName(connectionQN)
                     .apiSpecQualifiedName(specQN)
                     .apiSpecName(spec.title)
                     .apiSpecType(spec.openAPIVersion)
                     .apiFieldType(fieldType)
                     .apiObject(APIObject.refByQualifiedName(objectQN))
+                    .apiPathQualifiedName(pathQN)
+                    .apiMethodQualifiedName(methodQN)
+                    .apiBodyType(bodyType)
             if (fieldTypeSecondary != null) {
                 fieldBuilder.apiFieldTypeSecondary(fieldTypeSecondary)
             }
+            // Set description from the spec definition (always set to clear old values)
+            fieldBuilder.description(fieldSchema.description ?: "")
+
             if (isObjectRef) {
                 fieldBuilder.apiIsObjectReference(true)
-                val refQN = objectQNs[refSchemaName]
-                if (refQN != null) {
-                    fieldBuilder.apiObjectQualifiedName(refQN)
+
+                // Recurse into sub-objects if not a cycle
+                if (refSchemaName != null && refSchemaName !in visitedSchemas) {
+                    val resolvedSubSchema = resolveSchema(fieldSchema, spec.schemas)
+                    if (resolvedSubSchema != null && hasProperties(resolvedSubSchema)) {
+                        visitedSchemas.add(refSchemaName)
+                        val childContextPath = "$contextPath/$fieldName$arraySuffix"
+                        val childQN = createPhysicalSchemaObject(
+                            childContextPath, fieldDisplayName, rootSchemaName, resolvedSubSchema,
+                            specQN, connectionQN, pathQN, methodQN, bodyType,
+                            spec, objectBatch, fieldBatch, visitedSchemas,
+                        )
+                        fieldBuilder.apiObjectQualifiedName(childQN)
+                        visitedSchemas.remove(refSchemaName)
+                    }
                 }
             }
             fieldBatch.add(fieldBuilder.build())
         }
         return objectQN
     }
+
+    /**
+     * Create a shell APIObject for a response that has no object-type schema
+     * (primitive type, no content, or unresolved). This ensures every defined
+     * response appears in the hierarchy as a governable body entity.
+     *
+     * @return the qualified name of the created APIObject
+     */
+    private fun createShellResponseObject(
+        contextPath: String,
+        displayName: String,
+        bodyType: String,
+        specQN: String,
+        connectionQN: String,
+        pathQN: String,
+        methodQN: String,
+        spec: OpenAPISpecReader,
+        objectBatch: AssetBatch,
+    ): String {
+        val objectQN = "$specQN/schemas/$contextPath"
+        val apiObject =
+            APIObject
+                ._internal()
+                .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                .qualifiedName(objectQN)
+                .name(displayName)
+                .connectionQualifiedName(connectionQN)
+                .apiSpecQualifiedName(specQN)
+                .apiSpecName(spec.title)
+                .apiSpecType(spec.openAPIVersion)
+                .apiFieldCount(0L)
+                .apiPathQualifiedName(pathQN)
+                .apiMethodQualifiedName(methodQN)
+                .apiBodyType(bodyType)
+                .build()
+        objectBatch.add(apiObject)
+        return objectQN
+    }
+
+    /**
+     * Resolve a schema that may be a $ref to its full definition from components/schemas.
+     * Returns null if the schema cannot be resolved.
+     */
+    private fun resolveSchema(
+        schema: Schema<*>,
+        schemas: Map<String, Schema<*>>?,
+    ): Schema<*>? {
+        val refName = extractRefSchemaName(schema)
+        if (refName != null) {
+            return schemas?.get(refName)
+        }
+        // If it's an array with $ref items, resolve the item schema
+        if (schema.type == "array" && schema.items != null) {
+            val itemRefName = extractRefSchemaName(schema.items)
+            if (itemRefName != null) {
+                return schemas?.get(itemRefName)
+            }
+        }
+        // Inline schema — return it directly if it has properties
+        return schema
+    }
+
+    /**
+     * Check whether a schema has properties worth creating an APIObject for.
+     */
+    private fun hasProperties(schema: Schema<*>): Boolean =
+        schema.properties != null && schema.properties.isNotEmpty()
 
     /**
      * Sanitize a path URL for use in synthetic schema names.
@@ -569,11 +713,8 @@ object OpenAPISpecLoader {
      * Resolve the primary type of a field from its schema.
      */
     private fun resolveFieldType(schema: Schema<*>): String {
-        // If it's a $ref, resolve to "object"
         if (schema.`$ref` != null) return "object"
-        val type = schema.type ?: "object"
-        val format = schema.format
-        return if (format != null) "$type/$format" else type
+        return schema.type ?: "object"
     }
 
     /**
@@ -581,7 +722,6 @@ object OpenAPISpecLoader {
      */
     private fun resolveFieldTypeSecondary(schema: Schema<*>): String? {
         if (schema.type == "array") {
-            val itemType = schema.items?.type ?: if (schema.items?.`$ref` != null) "object" else "string"
             return "array"
         }
         return null
@@ -589,17 +729,144 @@ object OpenAPISpecLoader {
 
     /**
      * Serialize a schema to a JSON string for the blob attributes.
+     * Resolves $ref references and omits null values for cleaner output.
      */
-    private fun serializeSchema(schema: Schema<*>): String =
+    private fun serializeSchema(schema: Schema<*>, schemas: Map<String, Schema<*>>? = null): String =
         try {
-            jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(schema)
+            val resolved = if (schemas != null) resolveSchema(schema, schemas) ?: schema else schema
+            jsonMapper.writerWithDefaultPrettyPrinter().writeValueAsString(resolved)
         } catch (e: Exception) {
             schema.toString()
         }
 
     /**
+     * Generate an example payload from a schema definition.
+     * Uses the schema's `example` field when available, otherwise generates
+     * a representative value based on type and format.
+     * Arrays are limited to 1 item (or minItems if specified).
+     */
+    private fun generateExample(
+        schema: Schema<*>,
+        schemas: Map<String, Schema<*>>?,
+        visited: MutableSet<String> = mutableSetOf(),
+    ): Any? {
+        // Resolve $ref
+        val refName = extractRefSchemaName(schema)
+        if (refName != null) {
+            if (refName in visited) return emptyMap<String, Any>() // cycle guard
+            visited.add(refName)
+            val resolved = schemas?.get(refName)
+            val result = if (resolved != null) generateExample(resolved, schemas, visited) else null
+            visited.remove(refName)
+            return result
+        }
+
+        // Schema-level example takes priority
+        if (schema.example != null) return schema.example
+
+        // Array → generate 1 item (or minItems)
+        if (schema.type == "array" && schema.items != null) {
+            val itemExample = generateExample(schema.items, schemas, visited)
+            val count = schema.minItems ?: 1
+            return (1..count).map { itemExample }
+        }
+
+        // Object with properties
+        if (schema.properties != null && schema.properties.isNotEmpty()) {
+            val obj = linkedMapOf<String, Any?>()
+            for ((name, propSchema) in schema.properties) {
+                obj[name] = generateExample(propSchema, schemas, visited)
+            }
+            return obj
+        }
+
+        // Primitive
+        return generatePrimitiveExample(schema)
+    }
+
+    /**
+     * Generate a representative primitive value based on type and format.
+     */
+    private fun generatePrimitiveExample(schema: Schema<*>): Any {
+        if (schema.example != null) return schema.example
+
+        // Enum: pick first value
+        if (schema.enum != null && schema.enum.isNotEmpty()) return schema.enum[0]
+
+        return when (schema.type) {
+            "string" -> when (schema.format) {
+                "date-time" -> "2024-01-15T09:30:00Z"
+                "date" -> "2024-01-15"
+                "email" -> "user@example.com"
+                "uri", "url" -> "https://example.com"
+                "uuid" -> "550e8400-e29b-41d4-a716-446655440000"
+                "byte" -> "dGVzdA=="
+                "binary" -> "<binary>"
+                "password" -> "********"
+                else -> "string"
+            }
+            "integer", "int" -> when (schema.format) {
+                "int64" -> 100000L
+                else -> 10
+            }
+            "number" -> when (schema.format) {
+                "float" -> 3.14
+                "double" -> 3.14159
+                else -> 1.5
+            }
+            "boolean" -> true
+            else -> "value"
+        }
+    }
+
+    /**
+     * Create a relationship between two entities via the Atlas REST API.
+     * This bypasses the SDK's serialization which has swapped attribute names
+     * for the method↔object peer relationships.
+     */
+    private fun createRelationshipViaApi(
+        baseUrl: String,
+        apiToken: String,
+        relationshipTypeName: String,
+        end1QN: String,
+        end1Type: String,
+        end2QN: String,
+        end2Type: String,
+    ) {
+        try {
+            val payload = """
+                {
+                    "typeName": "$relationshipTypeName",
+                    "end1": {
+                        "typeName": "$end1Type",
+                        "uniqueAttributes": { "qualifiedName": "$end1QN" }
+                    },
+                    "end2": {
+                        "typeName": "$end2Type",
+                        "uniqueAttributes": { "qualifiedName": "$end2QN" }
+                    }
+                }
+            """.trimIndent()
+            val url = URL("$baseUrl/api/meta/relationship")
+            val conn = url.openConnection() as HttpURLConnection
+            conn.requestMethod = "POST"
+            conn.setRequestProperty("Authorization", "Bearer $apiToken")
+            conn.setRequestProperty("Content-Type", "application/json")
+            conn.doOutput = true
+            OutputStreamWriter(conn.outputStream).use { it.write(payload) }
+            val responseCode = conn.responseCode
+            if (responseCode !in 200..299) {
+                val error = conn.errorStream?.bufferedReader()?.readText() ?: ""
+                logger.warn { "Failed to create relationship $relationshipTypeName ($end1QN → $end2QN): HTTP $responseCode — $error" }
+            }
+            conn.disconnect()
+        } catch (e: Exception) {
+            logger.warn { "Error creating relationship $relationshipTypeName ($end1QN → $end2QN): ${e.message}" }
+        }
+    }
+
+    /**
      * Add the details of the provided operation to the details captured for the APIPath.
-     * (Unchanged from original — preserved for backward compatibility.)
      *
      * @param operation the operation to include (if non-null) as one that exists for the path
      * @param name the name of the operation
@@ -625,7 +892,7 @@ object OpenAPISpecLoader {
 
     /**
      * Utility class for parsing and reading the contents of an OpenAPI spec file,
-     * using the Swagger parser.
+     * using the Swagger parser. Also captures the raw file content for storage.
      */
     class OpenAPISpecReader(
         url: String,
@@ -647,6 +914,7 @@ object OpenAPISpecLoader {
         val licenseURL: String
         val externalDocsURL: String
         val externalDocsDescription: String
+        val rawContent: String
 
         init {
             spec = OpenAPIV3Parser().read(url)
@@ -665,6 +933,17 @@ object OpenAPISpecLoader {
             licenseURL = spec.info?.license?.url ?: ""
             externalDocsURL = spec.externalDocs?.url ?: ""
             externalDocsDescription = spec.externalDocs?.description ?: ""
+            // Capture raw content of the spec file
+            rawContent = try {
+                if (url.startsWith("http://") || url.startsWith("https://")) {
+                    URL(url).readText()
+                } else {
+                    Files.readString(Paths.get(url))
+                }
+            } catch (e: Exception) {
+                logger.warn { "Could not read raw spec content from $url: ${e.message}" }
+                ""
+            }
         }
     }
 }

--- a/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoaderCfg.kt
+++ b/samples/packages/openapi-spec-loader/src/main/kotlin/OpenAPISpecLoaderCfg.kt
@@ -28,4 +28,5 @@ data class OpenAPISpecLoaderCfg(
     @JsonDeserialize(using = WidgetSerde.MultiSelectDeserializer::class)
     @JsonSerialize(using = WidgetSerde.MultiSelectSerializer::class)
     @JsonProperty("connection_qualified_name") val connectionQualifiedName: List<String>? = null,
+    @JsonProperty("object_creation_mode") val objectCreationMode: String = "PHYSICAL",
 ) : CustomConfig<OpenAPISpecLoaderCfg>()

--- a/samples/packages/openapi-spec-loader/src/main/resources/package.pkl
+++ b/samples/packages/openapi-spec-loader/src/main/resources/package.pkl
@@ -87,6 +87,21 @@ uiConfig {
         }
       }
     }
+    ["Options"] {
+      description = "Asset creation options"
+      inputs {
+        ["object_creation_mode"] = new Radio {
+          title = "Schema object creation"
+          required = true
+          possibleValues {
+            ["PHYSICAL"] = "Physical instances (per-body, enables field-level lineage)"
+            ["NONE"] = "None (bodies-only, rely on JSON blobs on API Methods)"
+          }
+          default = "PHYSICAL"
+          helpText = "Physical creates separate API Object/Field assets for each request/response body occurrence. None skips object/field creation entirely to reduce asset count."
+        }
+      }
+    }
     ["Connection"] {
       description = "Connection details"
       inputs {

--- a/samples/packages/openapi-spec-loader/src/test/kotlin/ImportJsonTest.kt
+++ b/samples/packages/openapi-spec-loader/src/test/kotlin/ImportJsonTest.kt
@@ -237,6 +237,62 @@ class ImportJsonTest : PackageTest("j") {
     }
 
     @Test
+    fun methodResponseSchemaLinked() {
+        // Verify that methods with $ref response schemas are linked to APIObjects
+        val connectionQN = Connection.findByName(client, testId, connectorType)?.get(0)?.qualifiedName!!
+        val request =
+            APIMethod
+                .select(client)
+                .where(APIMethod.QUALIFIED_NAME.startsWith(connectionQN))
+                .includeOnResults(APIMethod.NAME)
+                .includeOnResults(APIMethod.API_METHOD_RESPONSE_SCHEMAS)
+                .includeOnResults(APIMethod.API_METHOD_RESPONSE_CODES)
+                .includeOnRelations(APIObject.QUALIFIED_NAME)
+                .toRequest()
+        val response = retrySearchUntil(request, 20)
+        val results = response.stream().toList()
+        // GET /pet/{petId} should have a response schema linked to the Pet APIObject
+        val getPetById = results.first { (it as APIMethod).name == "GET /pet/{petId}" } as APIMethod
+        assertNotNull(getPetById.apiMethodResponseSchemas, "GET /pet/{petId} should have response schemas")
+        assertFalse(getPetById.apiMethodResponseSchemas.isEmpty(), "GET /pet/{petId} should have at least one response schema")
+        assertTrue(
+            getPetById.apiMethodResponseSchemas.any {
+                (it as APIObject).uniqueAttributes.qualifiedName.contains("Pet")
+            },
+            "GET /pet/{petId} response should reference the Pet object",
+        )
+        // Verify response codes map is populated
+        assertNotNull(getPetById.apiMethodResponseCodes, "GET /pet/{petId} should have response codes")
+        assertTrue(getPetById.apiMethodResponseCodes.containsKey("200"), "GET /pet/{petId} should have a 200 response code")
+    }
+
+    @Test
+    fun objectRefFieldsLinked() {
+        // Verify that APIField objects referencing other schemas have apiIsObjectReference and apiObjectQualifiedName set
+        val connectionQN = Connection.findByName(client, testId, connectorType)?.get(0)?.qualifiedName!!
+        val request =
+            APIField
+                .select(client)
+                .where(APIField.QUALIFIED_NAME.startsWith(connectionQN))
+                .where(APIField.API_IS_OBJECT_REFERENCE.eq(true))
+                .includeOnResults(APIField.NAME)
+                .includeOnResults(APIField.API_IS_OBJECT_REFERENCE)
+                .includeOnResults(APIField.API_OBJECT_QUALIFIED_NAME)
+                .toRequest()
+        val response = retrySearchUntil(request, 1)
+        val results = response.stream().toList()
+        assertTrue(results.isNotEmpty(), "Should have fields with object references")
+        // Pet.category should reference the Category schema
+        val categoryField = results.firstOrNull { (it as APIField).name == "category" }
+        if (categoryField != null) {
+            val field = categoryField as APIField
+            assertEquals(true, field.apiIsObjectReference)
+            assertNotNull(field.apiObjectQualifiedName, "category field should have apiObjectQualifiedName")
+            assertTrue(field.apiObjectQualifiedName.contains("Category"), "category field should reference the Category schema")
+        }
+    }
+
+    @Test
     fun filesCreated() {
         validateFilesExist(files)
     }

--- a/samples/packages/openapi-spec-loader/src/test/kotlin/ImportJsonTest.kt
+++ b/samples/packages/openapi-spec-loader/src/test/kotlin/ImportJsonTest.kt
@@ -1,5 +1,8 @@
 /* SPDX-License-Identifier: Apache-2.0
    Copyright 2023 Atlan Pte. Ltd. */
+import com.atlan.model.assets.APIField
+import com.atlan.model.assets.APIMethod
+import com.atlan.model.assets.APIObject
 import com.atlan.model.assets.APIPath
 import com.atlan.model.assets.APISpec
 import com.atlan.model.assets.Connection
@@ -114,6 +117,122 @@ class ImportJsonTest : PackageTest("j") {
                     .startsWith(connectionQN),
             )
         }
+    }
+
+    @Test
+    fun objectsCreated() {
+        // The Petstore spec has 8 schemas: Order, Customer, Address, Category, User, Tag, Pet, ApiResponse
+        val connectionQN = Connection.findByName(client, testId, connectorType)?.get(0)?.qualifiedName!!
+        val request =
+            APIObject
+                .select(client)
+                .where(APIObject.QUALIFIED_NAME.startsWith(connectionQN))
+                .includeOnResults(APIObject.NAME)
+                .includeOnResults(APIObject.API_FIELD_COUNT)
+                .includeOnResults(APIObject.API_SPEC_QUALIFIED_NAME)
+                .toRequest()
+        val response = retrySearchUntil(request, 8)
+        val results = response.stream().toList()
+        assertEquals(8, results.size)
+        val objectNames = results.map { (it as APIObject).name }.toSet()
+        assertTrue(objectNames.contains("Pet"))
+        assertTrue(objectNames.contains("Order"))
+        assertTrue(objectNames.contains("User"))
+        assertTrue(objectNames.contains("Category"))
+        assertTrue(objectNames.contains("Tag"))
+        assertTrue(objectNames.contains("Address"))
+        assertTrue(objectNames.contains("Customer"))
+        assertTrue(objectNames.contains("ApiResponse"))
+        // Verify Pet has the correct field count (6 properties: id, name, category, photoUrls, tags, status)
+        val pet = results.first { (it as APIObject).name == "Pet" } as APIObject
+        assertEquals(6L, pet.apiFieldCount)
+    }
+
+    @Test
+    fun fieldsCreated() {
+        // Verify APIField assets were created for schema properties
+        val connectionQN = Connection.findByName(client, testId, connectorType)?.get(0)?.qualifiedName!!
+        val request =
+            APIField
+                .select(client)
+                .where(APIField.QUALIFIED_NAME.startsWith(connectionQN))
+                .includeOnResults(APIField.NAME)
+                .includeOnResults(APIField.API_FIELD_TYPE)
+                .includeOnResults(APIField.API_IS_OBJECT_REFERENCE)
+                .includeOnResults(APIField.API_OBJECT_QUALIFIED_NAME)
+                .includeOnResults(APIField.API_OBJECT)
+                .toRequest()
+        val response = retrySearchUntil(request, 1)
+        val results = response.stream().toList()
+        // There should be fields across all schemas
+        assertTrue(results.isNotEmpty())
+        // Find a field that is an object reference (e.g., Pet.category -> Category)
+        val objectRefFields = results.filter { (it as APIField).apiIsObjectReference == true }
+        assertTrue(objectRefFields.isNotEmpty(), "Should have at least one field that references another APIObject")
+        // Every field should have a parent APIObject
+        results.forEach {
+            val field = it as APIField
+            assertFalse(field.name.isNullOrBlank())
+            assertFalse(field.apiFieldType.isNullOrBlank())
+        }
+    }
+
+    @Test
+    fun methodsCreated() {
+        // The Petstore spec has 20 operations total across all paths
+        val connectionQN = Connection.findByName(client, testId, connectorType)?.get(0)?.qualifiedName!!
+        val request =
+            APIMethod
+                .select(client)
+                .where(APIMethod.QUALIFIED_NAME.startsWith(connectionQN))
+                .includeOnResults(APIMethod.NAME)
+                .includeOnResults(APIMethod.DESCRIPTION)
+                .includeOnResults(APIMethod.API_METHOD_REQUEST)
+                .includeOnResults(APIMethod.API_METHOD_RESPONSE)
+                .includeOnResults(APIMethod.API_METHOD_RESPONSE_CODES)
+                .includeOnResults(APIMethod.API_PATH)
+                .includeOnRelations(APIPath.QUALIFIED_NAME)
+                .toRequest()
+        val response = retrySearchUntil(request, 20)
+        val results = response.stream().toList()
+        assertEquals(20, results.size)
+        results.forEach {
+            val method = it as APIMethod
+            assertTrue(method.qualifiedName.startsWith(connectionQN))
+            assertFalse(method.name.isNullOrBlank())
+            // Every method should have a parent APIPath
+            assertNotNull(method.apiPath)
+            assertTrue(method.apiPath is APIPath)
+        }
+        // Verify a specific method: PUT /pet should have request and response
+        val putPet = results.first { (it as APIMethod).name == "PUT /pet" } as APIMethod
+        assertNotNull(putPet.apiMethodRequest, "PUT /pet should have a request body")
+        assertNotNull(putPet.apiMethodResponse, "PUT /pet should have a response body")
+        assertNotNull(putPet.apiMethodResponseCodes, "PUT /pet should have response codes")
+        assertTrue(putPet.apiMethodResponseCodes.containsKey("200"), "PUT /pet should have a 200 response")
+    }
+
+    @Test
+    fun methodRequestSchemaLinked() {
+        // Verify that methods with request bodies are linked to APIObjects
+        val connectionQN = Connection.findByName(client, testId, connectorType)?.get(0)?.qualifiedName!!
+        val request =
+            APIMethod
+                .select(client)
+                .where(APIMethod.QUALIFIED_NAME.startsWith(connectionQN))
+                .includeOnResults(APIMethod.NAME)
+                .includeOnResults(APIMethod.API_METHOD_REQUEST_SCHEMA)
+                .includeOnRelations(APIObject.QUALIFIED_NAME)
+                .toRequest()
+        val response = retrySearchUntil(request, 20)
+        val results = response.stream().toList()
+        // POST /pet should have its request schema linked to the Pet APIObject
+        val postPet = results.first { (it as APIMethod).name == "POST /pet" } as APIMethod
+        assertNotNull(postPet.apiMethodRequestSchema, "POST /pet should be linked to a request schema APIObject")
+        assertTrue(
+            postPet.apiMethodRequestSchema.uniqueAttributes.qualifiedName.contains("Pet"),
+            "POST /pet request schema should reference the Pet object",
+        )
     }
 
     @Test

--- a/samples/packages/openapi-spec-loader/src/test/kotlin/ImportJsonTest.kt
+++ b/samples/packages/openapi-spec-loader/src/test/kotlin/ImportJsonTest.kt
@@ -230,7 +230,8 @@ class ImportJsonTest : PackageTest("j") {
         val postPet = results.first { (it as APIMethod).name == "POST /pet" } as APIMethod
         assertNotNull(postPet.apiMethodRequestSchema, "POST /pet should be linked to a request schema APIObject")
         assertTrue(
-            postPet.apiMethodRequestSchema.uniqueAttributes.qualifiedName.contains("Pet"),
+            postPet.apiMethodRequestSchema.uniqueAttributes.qualifiedName
+                .contains("Pet"),
             "POST /pet request schema should reference the Pet object",
         )
     }

--- a/sdk/src/main/java/com/atlan/model/assets/APIField.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIField.java
@@ -49,6 +49,10 @@ public class APIField extends Asset implements IAPIField, IAPI, ICatalog, IAsset
     @Builder.Default
     String typeName = TYPE_NAME;
 
+    /** Type of API body this field belongs to (e.g. "request", "response/200"). */
+    @Attribute
+    String apiBodyType;
+
     /** External documentation of the API. */
     @Attribute
     @Singular
@@ -70,6 +74,10 @@ public class APIField extends Asset implements IAPIField, IAPI, ICatalog, IAsset
     @Attribute
     Boolean apiIsObjectReference;
 
+    /** Qualified name of the API method this field belongs to. */
+    @Attribute
+    String apiMethodQualifiedName;
+
     /** APIObject asset containing this APIField. */
     @Attribute
     IAPIObject apiObject;
@@ -77,6 +85,10 @@ public class APIField extends Asset implements IAPIField, IAPI, ICatalog, IAsset
     /** Qualified name of the APIObject that is referred to by this asset. When apiIsObjectReference is true. */
     @Attribute
     String apiObjectQualifiedName;
+
+    /** Qualified name of the API path this field belongs to. */
+    @Attribute
+    String apiPathQualifiedName;
 
     /** APIQuery asset containing this APIField. */
     @Attribute

--- a/sdk/src/main/java/com/atlan/model/assets/APIMethod.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIMethod.java
@@ -44,6 +44,38 @@ public class APIMethod extends Asset implements IAPIMethod, IAPI, ICatalog, IAss
 
     public static final String TYPE_NAME = "APIMethod";
 
+    // Override all default methods that conflict between IAPI and ICatalog interfaces.
+    @Override public IApplication getApplication() { return null; }
+    @Override public IApplicationField getApplicationField() { return null; }
+    @Override public IDataContract getDataContractLatest() { return null; }
+    @Override public IDataContract getDataContractLatestCertified() { return null; }
+    @Override public IReadme getReadme() { return null; }
+    @Override public SortedSet<IAirflowTask> getInputToAirflowTasks() { return null; }
+    @Override public SortedSet<IAirflowTask> getOutputFromAirflowTasks() { return null; }
+    @Override public SortedSet<IAnomaloCheck> getAnomaloChecks() { return null; }
+    @Override public SortedSet<IAsset> getUserDefRelationshipFroms() { return null; }
+    @Override public SortedSet<IAsset> getUserDefRelationshipTos() { return null; }
+    @Override public SortedSet<IDataProduct> getInputPortDataProducts() { return null; }
+    @Override public SortedSet<IDataProduct> getOutputPortDataProducts() { return null; }
+    @Override public SortedSet<IDataQualityRule> getDqBaseDatasetRules() { return null; }
+    @Override public SortedSet<IDataQualityRule> getDqReferenceDatasetRules() { return null; }
+    @Override public SortedSet<IFile> getFiles() { return null; }
+    @Override public SortedSet<IGlossaryTerm> getAssignedTerms() { return null; }
+    @Override public SortedSet<ILineageProcess> getInputToProcesses() { return null; }
+    @Override public SortedSet<ILineageProcess> getOutputFromProcesses() { return null; }
+    @Override public SortedSet<ILink> getLinks() { return null; }
+    @Override public SortedSet<IMCIncident> getMcIncidents() { return null; }
+    @Override public SortedSet<IMCMonitor> getMcMonitors() { return null; }
+    @Override public SortedSet<IMetric> getMetrics() { return null; }
+    @Override public SortedSet<IModelAttribute> getModelImplementedAttributes() { return null; }
+    @Override public SortedSet<IModelEntity> getModelImplementedEntities() { return null; }
+    @Override public SortedSet<IPartialField> getPartialChildFields() { return null; }
+    @Override public SortedSet<IPartialObject> getPartialChildObjects() { return null; }
+    @Override public SortedSet<ISchemaRegistrySubject> getSchemaRegistrySubjects() { return null; }
+    @Override public SortedSet<ISodaCheck> getSodaChecks() { return null; }
+    @Override public SortedSet<ISparkJob> getInputToSparkJobs() { return null; }
+    @Override public SortedSet<ISparkJob> getOutputFromSparkJobs() { return null; }
+
     /** Fixed typeName for APIMethods. */
     @Getter(onMethod_ = {@Override})
     @Builder.Default

--- a/sdk/src/main/java/com/atlan/model/assets/APIMethod.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIMethod.java
@@ -29,7 +29,8 @@ import lombok.experimental.SuperBuilder;
 import lombok.extern.slf4j.Slf4j;
 
 /**
- * Instances of APIObject in Atlan.
+ * Instance of an API method (operation) on a path in Atlan.
+ * Represents a single HTTP method such as GET, POST, PUT, DELETE on an APIPath.
  */
 @Generated(value = "com.atlan.generators.ModelGeneratorV2")
 @Getter
@@ -38,12 +39,12 @@ import lombok.extern.slf4j.Slf4j;
 @ToString(callSuper = true)
 @Slf4j
 @SuppressWarnings({"cast", "serial"})
-public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAsset, IReferenceable {
+public class APIMethod extends Asset implements IAPIMethod, IAPI, ICatalog, IAsset, IReferenceable {
     private static final long serialVersionUID = 2L;
 
-    public static final String TYPE_NAME = "APIObject";
+    public static final String TYPE_NAME = "APIMethod";
 
-    /** Fixed typeName for APIObjects. */
+    /** Fixed typeName for APIMethods. */
     @Getter(onMethod_ = {@Override})
     @Builder.Default
     String typeName = TYPE_NAME;
@@ -53,36 +54,43 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     @Singular
     Map<String, String> apiExternalDocs;
 
-    /** Count of the APIField of this object. */
-    @Attribute
-    Long apiFieldCount;
-
-    /** APIField assets contained within this APIObject. */
-    @Attribute
-    @Singular
-    SortedSet<IAPIField> apiFields;
-
     /** Whether authentication is optional (true) or required (false). */
     @Attribute
     Boolean apiIsAuthOptional;
-
-    /** API methods that use this object as their request schema. */
-    @Attribute
-    @Singular
-    SortedSet<IAPIMethod> apiMethodsRequestingThis;
-
-    /** API methods that use this object as one of their response schemas. */
-    @Attribute
-    @Singular
-    SortedSet<IAPIMethod> apiMethodsRespondingWithThis;
 
     /** If this asset refers to an APIObject */
     @Attribute
     Boolean apiIsObjectReference;
 
+    /** Request body or schema information for this API method. */
+    @Attribute
+    String apiMethodRequest;
+
+    /** APIObject schema describing this method's request body. */
+    @Attribute
+    IAPIObject apiMethodRequestSchema;
+
+    /** Response body or schema information for this API method. */
+    @Attribute
+    String apiMethodResponse;
+
+    /** Map of HTTP response status codes to the qualified names of the APIObject schemas that describe each response. */
+    @Attribute
+    @Singular
+    Map<String, String> apiMethodResponseCodes;
+
+    /** APIObject schemas describing this method's response bodies. */
+    @Attribute
+    @Singular("apiMethodResponseSchema")
+    SortedSet<IAPIObject> apiMethodResponseSchemas;
+
     /** Qualified name of the APIObject that is referred to by this asset. When apiIsObjectReference is true. */
     @Attribute
     String apiObjectQualifiedName;
+
+    /** API path on which this method operates. */
+    @Attribute
+    IAPIPath apiPath;
 
     /** Simple name of the API spec, if this asset is contained in an API spec. */
     @Attribute
@@ -140,25 +148,15 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     @Singular
     SortedSet<ISparkJob> outputFromSparkJobs;
 
-    /** Partial fields contained in the asset. */
-    @Attribute
-    @Singular
-    SortedSet<IPartialField> partialChildFields;
-
-    /** Partial objects contained in the asset. */
-    @Attribute
-    @Singular
-    SortedSet<IPartialObject> partialChildObjects;
-
     /**
-     * Builds the minimal object necessary to create a relationship to a APIObject, from a potentially
-     * more-complete APIObject object.
+     * Builds the minimal object necessary to create a relationship to a APIMethod, from a potentially
+     * more-complete APIMethod object.
      *
-     * @return the minimal object necessary to relate to the APIObject
-     * @throws InvalidRequestException if any of the minimal set of required properties for a APIObject relationship are not found in the initial object
+     * @return the minimal object necessary to relate to the APIMethod
+     * @throws InvalidRequestException if any of the minimal set of required properties for a APIMethod relationship are not found in the initial object
      */
     @Override
-    public APIObject trimToReference() throws InvalidRequestException {
+    public APIMethod trimToReference() throws InvalidRequestException {
         if (this.getGuid() != null && !this.getGuid().isEmpty()) {
             return refByGuid(this.getGuid());
         }
@@ -175,27 +173,27 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     }
 
     /**
-     * Start a fluent search that will return all APIObject assets.
+     * Start a fluent search that will return all APIMethod assets.
      * Additional conditions can be chained onto the returned search before any
      * asset retrieval is attempted, ensuring all conditions are pushed-down for
-     * optimal retrieval. Only active (non-archived) APIObject assets will be included.
+     * optimal retrieval. Only active (non-archived) APIMethod assets will be included.
      *
      * @param client connectivity to the Atlan tenant from which to retrieve the assets
-     * @return a fluent search that includes all APIObject assets
+     * @return a fluent search that includes all APIMethod assets
      */
     public static FluentSearch.FluentSearchBuilder<?, ?> select(AtlanClient client) {
         return select(client, false);
     }
 
     /**
-     * Start a fluent search that will return all APIObject assets.
+     * Start a fluent search that will return all APIMethod assets.
      * Additional conditions can be chained onto the returned search before any
      * asset retrieval is attempted, ensuring all conditions are pushed-down for
      * optimal retrieval.
      *
      * @param client connectivity to the Atlan tenant from which to retrieve the assets
-     * @param includeArchived when true, archived (soft-deleted) APIObjects will be included
-     * @return a fluent search that includes all APIObject assets
+     * @param includeArchived when true, archived (soft-deleted) APIMethods will be included
+     * @return a fluent search that includes all APIMethod assets
      */
     public static FluentSearch.FluentSearchBuilder<?, ?> select(AtlanClient client, boolean includeArchived) {
         FluentSearch.FluentSearchBuilder<?, ?> builder =
@@ -207,51 +205,51 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     }
 
     /**
-     * Reference to a APIObject by GUID. Use this to create a relationship to this APIObject,
+     * Reference to a APIMethod by GUID. Use this to create a relationship to this APIMethod,
      * where the relationship should be replaced.
      *
-     * @param guid the GUID of the APIObject to reference
-     * @return reference to a APIObject that can be used for defining a relationship to a APIObject
+     * @param guid the GUID of the APIMethod to reference
+     * @return reference to a APIMethod that can be used for defining a relationship to a APIMethod
      */
-    public static APIObject refByGuid(String guid) {
+    public static APIMethod refByGuid(String guid) {
         return refByGuid(guid, Reference.SaveSemantic.REPLACE);
     }
 
     /**
-     * Reference to a APIObject by GUID. Use this to create a relationship to this APIObject,
+     * Reference to a APIMethod by GUID. Use this to create a relationship to this APIMethod,
      * where you want to further control how that relationship should be updated (i.e. replaced,
      * appended, or removed).
      *
-     * @param guid the GUID of the APIObject to reference
+     * @param guid the GUID of the APIMethod to reference
      * @param semantic how to save this relationship (replace all with this, append it, or remove it)
-     * @return reference to a APIObject that can be used for defining a relationship to a APIObject
+     * @return reference to a APIMethod that can be used for defining a relationship to a APIMethod
      */
-    public static APIObject refByGuid(String guid, Reference.SaveSemantic semantic) {
-        return APIObject._internal().guid(guid).semantic(semantic).build();
+    public static APIMethod refByGuid(String guid, Reference.SaveSemantic semantic) {
+        return APIMethod._internal().guid(guid).semantic(semantic).build();
     }
 
     /**
-     * Reference to a APIObject by qualifiedName. Use this to create a relationship to this APIObject,
+     * Reference to a APIMethod by qualifiedName. Use this to create a relationship to this APIMethod,
      * where the relationship should be replaced.
      *
-     * @param qualifiedName the qualifiedName of the APIObject to reference
-     * @return reference to a APIObject that can be used for defining a relationship to a APIObject
+     * @param qualifiedName the qualifiedName of the APIMethod to reference
+     * @return reference to a APIMethod that can be used for defining a relationship to a APIMethod
      */
-    public static APIObject refByQualifiedName(String qualifiedName) {
+    public static APIMethod refByQualifiedName(String qualifiedName) {
         return refByQualifiedName(qualifiedName, Reference.SaveSemantic.REPLACE);
     }
 
     /**
-     * Reference to a APIObject by qualifiedName. Use this to create a relationship to this APIObject,
+     * Reference to a APIMethod by qualifiedName. Use this to create a relationship to this APIMethod,
      * where you want to further control how that relationship should be updated (i.e. replaced,
      * appended, or removed).
      *
-     * @param qualifiedName the qualifiedName of the APIObject to reference
+     * @param qualifiedName the qualifiedName of the APIMethod to reference
      * @param semantic how to save this relationship (replace all with this, append it, or remove it)
-     * @return reference to a APIObject that can be used for defining a relationship to a APIObject
+     * @return reference to a APIMethod that can be used for defining a relationship to a APIMethod
      */
-    public static APIObject refByQualifiedName(String qualifiedName, Reference.SaveSemantic semantic) {
-        return APIObject._internal()
+    public static APIMethod refByQualifiedName(String qualifiedName, Reference.SaveSemantic semantic) {
+        return APIMethod._internal()
                 .uniqueAttributes(
                         UniqueAttributes.builder().qualifiedName(qualifiedName).build())
                 .semantic(semantic)
@@ -259,44 +257,44 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     }
 
     /**
-     * Retrieves a APIObject by one of its identifiers, complete with all of its relationships.
+     * Retrieves a APIMethod by one of its identifiers, complete with all of its relationships.
      *
      * @param client connectivity to the Atlan tenant from which to retrieve the asset
-     * @param id of the APIObject to retrieve, either its GUID or its full qualifiedName
-     * @return the requested full APIObject, complete with all of its relationships
-     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the APIObject does not exist or the provided GUID is not a APIObject
+     * @param id of the APIMethod to retrieve, either its GUID or its full qualifiedName
+     * @return the requested full APIMethod, complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the APIMethod does not exist or the provided GUID is not a APIMethod
      */
     @JsonIgnore
-    public static APIObject get(AtlanClient client, String id) throws AtlanException {
+    public static APIMethod get(AtlanClient client, String id) throws AtlanException {
         return get(client, id, false);
     }
 
     /**
-     * Retrieves a APIObject by one of its identifiers, optionally complete with all of its relationships.
+     * Retrieves a APIMethod by one of its identifiers, optionally complete with all of its relationships.
      *
      * @param client connectivity to the Atlan tenant from which to retrieve the asset
-     * @param id of the APIObject to retrieve, either its GUID or its full qualifiedName
+     * @param id of the APIMethod to retrieve, either its GUID or its full qualifiedName
      * @param includeAllRelationships if true, all the asset's relationships will also be retrieved; if false, no relationships will be retrieved
-     * @return the requested full APIObject, optionally complete with all of its relationships
-     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the APIObject does not exist or the provided GUID is not a APIObject
+     * @return the requested full APIMethod, optionally complete with all of its relationships
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the APIMethod does not exist or the provided GUID is not a APIMethod
      */
     @JsonIgnore
-    public static APIObject get(AtlanClient client, String id, boolean includeAllRelationships) throws AtlanException {
+    public static APIMethod get(AtlanClient client, String id, boolean includeAllRelationships) throws AtlanException {
         if (id == null) {
             throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, "(null)");
         } else if (StringUtils.isUUID(id)) {
             Asset asset = Asset.get(client, id, includeAllRelationships);
             if (asset == null) {
                 throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, id);
-            } else if (asset instanceof APIObject) {
-                return (APIObject) asset;
+            } else if (asset instanceof APIMethod) {
+                return (APIMethod) asset;
             } else {
                 throw new NotFoundException(ErrorCode.ASSET_NOT_TYPE_REQUESTED, id, TYPE_NAME);
             }
         } else {
             Asset asset = Asset.get(client, TYPE_NAME, id, includeAllRelationships);
-            if (asset instanceof APIObject) {
-                return (APIObject) asset;
+            if (asset instanceof APIMethod) {
+                return (APIMethod) asset;
             } else {
                 throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_QN, id, TYPE_NAME);
             }
@@ -304,32 +302,32 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     }
 
     /**
-     * Retrieves a APIObject by one of its identifiers, with only the requested attributes (and relationships).
+     * Retrieves a APIMethod by one of its identifiers, with only the requested attributes (and relationships).
      *
      * @param client connectivity to the Atlan tenant from which to retrieve the asset
-     * @param id of the APIObject to retrieve, either its GUID or its full qualifiedName
-     * @param attributes to retrieve for the APIObject, including any relationships
-     * @return the requested APIObject, with only its minimal information and the requested attributes (and relationships)
-     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the APIObject does not exist or the provided GUID is not a APIObject
+     * @param id of the APIMethod to retrieve, either its GUID or its full qualifiedName
+     * @param attributes to retrieve for the APIMethod, including any relationships
+     * @return the requested APIMethod, with only its minimal information and the requested attributes (and relationships)
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the APIMethod does not exist or the provided GUID is not a APIMethod
      */
     @JsonIgnore
-    public static APIObject get(AtlanClient client, String id, Collection<AtlanField> attributes)
+    public static APIMethod get(AtlanClient client, String id, Collection<AtlanField> attributes)
             throws AtlanException {
         return get(client, id, attributes, Collections.emptyList());
     }
 
     /**
-     * Retrieves a APIObject by one of its identifiers, with only the requested attributes (and relationships).
+     * Retrieves a APIMethod by one of its identifiers, with only the requested attributes (and relationships).
      *
      * @param client connectivity to the Atlan tenant from which to retrieve the asset
-     * @param id of the APIObject to retrieve, either its GUID or its full qualifiedName
-     * @param attributes to retrieve for the APIObject, including any relationships
-     * @param attributesOnRelated to retrieve on each relationship retrieved for the APIObject
-     * @return the requested APIObject, with only its minimal information and the requested attributes (and relationships)
-     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the APIObject does not exist or the provided GUID is not a APIObject
+     * @param id of the APIMethod to retrieve, either its GUID or its full qualifiedName
+     * @param attributes to retrieve for the APIMethod, including any relationships
+     * @param attributesOnRelated to retrieve on each relationship retrieved for the APIMethod
+     * @return the requested APIMethod, with only its minimal information and the requested attributes (and relationships)
+     * @throws AtlanException on any error during the API invocation, such as the {@link NotFoundException} if the APIMethod does not exist or the provided GUID is not a APIMethod
      */
     @JsonIgnore
-    public static APIObject get(
+    public static APIMethod get(
             AtlanClient client,
             String id,
             Collection<AtlanField> attributes,
@@ -338,8 +336,8 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
         if (id == null) {
             throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, "(null)");
         } else if (StringUtils.isUUID(id)) {
-            Optional<Asset> asset = APIObject.select(client)
-                    .where(APIObject.GUID.eq(id))
+            Optional<Asset> asset = APIMethod.select(client)
+                    .where(APIMethod.GUID.eq(id))
                     .includesOnResults(attributes)
                     .includesOnRelations(attributesOnRelated)
                     .includeRelationshipAttributes(true)
@@ -348,14 +346,14 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
                     .findFirst();
             if (!asset.isPresent()) {
                 throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_GUID, id);
-            } else if (asset.get() instanceof APIObject) {
-                return (APIObject) asset.get();
+            } else if (asset.get() instanceof APIMethod) {
+                return (APIMethod) asset.get();
             } else {
                 throw new NotFoundException(ErrorCode.ASSET_NOT_TYPE_REQUESTED, id, TYPE_NAME);
             }
         } else {
-            Optional<Asset> asset = APIObject.select(client)
-                    .where(APIObject.QUALIFIED_NAME.eq(id))
+            Optional<Asset> asset = APIMethod.select(client)
+                    .where(APIMethod.QUALIFIED_NAME.eq(id))
                     .includesOnResults(attributes)
                     .includesOnRelations(attributesOnRelated)
                     .includeRelationshipAttributes(true)
@@ -364,8 +362,8 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
                     .findFirst();
             if (!asset.isPresent()) {
                 throw new NotFoundException(ErrorCode.ASSET_NOT_FOUND_BY_QN, id, TYPE_NAME);
-            } else if (asset.get() instanceof APIObject) {
-                return (APIObject) asset.get();
+            } else if (asset.get() instanceof APIMethod) {
+                return (APIMethod) asset.get();
             } else {
                 throw new NotFoundException(ErrorCode.ASSET_NOT_TYPE_REQUESTED, id, TYPE_NAME);
             }
@@ -373,11 +371,11 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     }
 
     /**
-     * Restore the archived (soft-deleted) APIObject to active.
+     * Restore the archived (soft-deleted) APIMethod to active.
      *
      * @param client connectivity to the Atlan tenant on which to restore the asset
-     * @param qualifiedName for the APIObject
-     * @return true if the APIObject is now active, and false otherwise
+     * @param qualifiedName for the APIMethod
+     * @return true if the APIMethod is now active, and false otherwise
      * @throws AtlanException on any API problems
      */
     public static boolean restore(AtlanClient client, String qualifiedName) throws AtlanException {
@@ -385,28 +383,28 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     }
 
     /**
-     * Builds the minimal object necessary to update a APIObject.
+     * Builds the minimal object necessary to update a APIMethod.
      *
-     * @param qualifiedName of the APIObject
-     * @param name of the APIObject
-     * @return the minimal request necessary to update the APIObject, as a builder
+     * @param qualifiedName of the APIMethod
+     * @param name of the APIMethod
+     * @return the minimal request necessary to update the APIMethod, as a builder
      */
-    public static APIObjectBuilder<?, ?> updater(String qualifiedName, String name) {
-        return APIObject._internal()
+    public static APIMethodBuilder<?, ?> updater(String qualifiedName, String name) {
+        return APIMethod._internal()
                 .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
                 .qualifiedName(qualifiedName)
                 .name(name);
     }
 
     /**
-     * Builds the minimal object necessary to apply an update to a APIObject,
-     * from a potentially more-complete APIObject object.
+     * Builds the minimal object necessary to apply an update to a APIMethod,
+     * from a potentially more-complete APIMethod object.
      *
-     * @return the minimal object necessary to update the APIObject, as a builder
-     * @throws InvalidRequestException if any of the minimal set of required fields for a APIObject are not present in the initial object
+     * @return the minimal object necessary to update the APIMethod, as a builder
+     * @throws InvalidRequestException if any of the minimal set of required fields for a APIMethod are not present in the initial object
      */
     @Override
-    public APIObjectBuilder<?, ?> trimToRequired() throws InvalidRequestException {
+    public APIMethodBuilder<?, ?> trimToRequired() throws InvalidRequestException {
         Map<String, String> map = new HashMap<>();
         map.put("qualifiedName", this.getQualifiedName());
         map.put("name", this.getName());
@@ -414,198 +412,198 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
         return updater(this.getQualifiedName(), this.getName());
     }
 
-    public abstract static class APIObjectBuilder<C extends APIObject, B extends APIObjectBuilder<C, B>>
+    public abstract static class APIMethodBuilder<C extends APIMethod, B extends APIMethodBuilder<C, B>>
             extends Asset.AssetBuilder<C, B> {}
 
     /**
-     * Remove the system description from a APIObject.
+     * Remove the system description from a APIMethod.
      *
      * @param client connectivity to the Atlan tenant on which to remove the asset's description
-     * @param qualifiedName of the APIObject
-     * @param name of the APIObject
-     * @return the updated APIObject, or null if the removal failed
+     * @param qualifiedName of the APIMethod
+     * @param name of the APIMethod
+     * @return the updated APIMethod, or null if the removal failed
      * @throws AtlanException on any API problems
      */
-    public static APIObject removeDescription(AtlanClient client, String qualifiedName, String name)
+    public static APIMethod removeDescription(AtlanClient client, String qualifiedName, String name)
             throws AtlanException {
-        return (APIObject) Asset.removeDescription(client, updater(qualifiedName, name));
+        return (APIMethod) Asset.removeDescription(client, updater(qualifiedName, name));
     }
 
     /**
-     * Remove the user's description from a APIObject.
+     * Remove the user's description from a APIMethod.
      *
      * @param client connectivity to the Atlan tenant on which to remove the asset's description
-     * @param qualifiedName of the APIObject
-     * @param name of the APIObject
-     * @return the updated APIObject, or null if the removal failed
+     * @param qualifiedName of the APIMethod
+     * @param name of the APIMethod
+     * @return the updated APIMethod, or null if the removal failed
      * @throws AtlanException on any API problems
      */
-    public static APIObject removeUserDescription(AtlanClient client, String qualifiedName, String name)
+    public static APIMethod removeUserDescription(AtlanClient client, String qualifiedName, String name)
             throws AtlanException {
-        return (APIObject) Asset.removeUserDescription(client, updater(qualifiedName, name));
+        return (APIMethod) Asset.removeUserDescription(client, updater(qualifiedName, name));
     }
 
     /**
-     * Remove the owners from a APIObject.
+     * Remove the owners from a APIMethod.
      *
-     * @param client connectivity to the Atlan tenant from which to remove the APIObject's owners
-     * @param qualifiedName of the APIObject
-     * @param name of the APIObject
-     * @return the updated APIObject, or null if the removal failed
+     * @param client connectivity to the Atlan client from which to remove the APIMethod's owners
+     * @param qualifiedName of the APIMethod
+     * @param name of the APIMethod
+     * @return the updated APIMethod, or null if the removal failed
      * @throws AtlanException on any API problems
      */
-    public static APIObject removeOwners(AtlanClient client, String qualifiedName, String name) throws AtlanException {
-        return (APIObject) Asset.removeOwners(client, updater(qualifiedName, name));
+    public static APIMethod removeOwners(AtlanClient client, String qualifiedName, String name) throws AtlanException {
+        return (APIMethod) Asset.removeOwners(client, updater(qualifiedName, name));
     }
 
     /**
-     * Update the certificate on a APIObject.
+     * Update the certificate on a APIMethod.
      *
-     * @param client connectivity to the Atlan tenant on which to update the APIObject's certificate
-     * @param qualifiedName of the APIObject
+     * @param client connectivity to the Atlan tenant on which to update the APIMethod's certificate
+     * @param qualifiedName of the APIMethod
      * @param certificate to use
      * @param message (optional) message, or null if no message
-     * @return the updated APIObject, or null if the update failed
+     * @return the updated APIMethod, or null if the update failed
      * @throws AtlanException on any API problems
      */
-    public static APIObject updateCertificate(
+    public static APIMethod updateCertificate(
             AtlanClient client, String qualifiedName, CertificateStatus certificate, String message)
             throws AtlanException {
-        return (APIObject) Asset.updateCertificate(client, _internal(), TYPE_NAME, qualifiedName, certificate, message);
+        return (APIMethod) Asset.updateCertificate(client, _internal(), TYPE_NAME, qualifiedName, certificate, message);
     }
 
     /**
-     * Remove the certificate from a APIObject.
+     * Remove the certificate from a APIMethod.
      *
-     * @param client connectivity to the Atlan tenant from which to remove the APIObject's certificate
-     * @param qualifiedName of the APIObject
-     * @param name of the APIObject
-     * @return the updated APIObject, or null if the removal failed
+     * @param client connectivity to the Atlan tenant from which to remove the APIMethod's certificate
+     * @param qualifiedName of the APIMethod
+     * @param name of the APIMethod
+     * @return the updated APIMethod, or null if the removal failed
      * @throws AtlanException on any API problems
      */
-    public static APIObject removeCertificate(AtlanClient client, String qualifiedName, String name)
+    public static APIMethod removeCertificate(AtlanClient client, String qualifiedName, String name)
             throws AtlanException {
-        return (APIObject) Asset.removeCertificate(client, updater(qualifiedName, name));
+        return (APIMethod) Asset.removeCertificate(client, updater(qualifiedName, name));
     }
 
     /**
-     * Update the announcement on a APIObject.
+     * Update the announcement on a APIMethod.
      *
-     * @param client connectivity to the Atlan tenant on which to update the APIObject's announcement
-     * @param qualifiedName of the APIObject
+     * @param client connectivity to the Atlan tenant on which to update the APIMethod's announcement
+     * @param qualifiedName of the APIMethod
      * @param type type of announcement to set
      * @param title (optional) title of the announcement to set (or null for no title)
      * @param message (optional) message of the announcement to set (or null for no message)
      * @return the result of the update, or null if the update failed
      * @throws AtlanException on any API problems
      */
-    public static APIObject updateAnnouncement(
+    public static APIMethod updateAnnouncement(
             AtlanClient client, String qualifiedName, AtlanAnnouncementType type, String title, String message)
             throws AtlanException {
-        return (APIObject)
+        return (APIMethod)
                 Asset.updateAnnouncement(client, _internal(), TYPE_NAME, qualifiedName, type, title, message);
     }
 
     /**
-     * Remove the announcement from a APIObject.
+     * Remove the announcement from a APIMethod.
      *
-     * @param client connectivity to the Atlan client from which to remove the APIObject's announcement
-     * @param qualifiedName of the APIObject
-     * @param name of the APIObject
-     * @return the updated APIObject, or null if the removal failed
+     * @param client connectivity to the Atlan client from which to remove the APIMethod's announcement
+     * @param qualifiedName of the APIMethod
+     * @param name of the APIMethod
+     * @return the updated APIMethod, or null if the removal failed
      * @throws AtlanException on any API problems
      */
-    public static APIObject removeAnnouncement(AtlanClient client, String qualifiedName, String name)
+    public static APIMethod removeAnnouncement(AtlanClient client, String qualifiedName, String name)
             throws AtlanException {
-        return (APIObject) Asset.removeAnnouncement(client, updater(qualifiedName, name));
+        return (APIMethod) Asset.removeAnnouncement(client, updater(qualifiedName, name));
     }
 
     /**
-     * Replace the terms linked to the APIObject.
+     * Replace the terms linked to the APIMethod.
      *
-     * @param client connectivity to the Atlan tenant on which to replace the APIObject's assigned terms
-     * @param qualifiedName for the APIObject
-     * @param name human-readable name of the APIObject
-     * @param terms the list of terms to replace on the APIObject, or null to remove all terms from the APIObject
-     * @return the APIObject that was updated (note that it will NOT contain details of the replaced terms)
+     * @param client connectivity to the Atlan tenant on which to replace the APIMethod's assigned terms
+     * @param qualifiedName for the APIMethod
+     * @param name human-readable name of the APIMethod
+     * @param terms the list of terms to replace on the APIMethod, or null to remove all terms from the APIMethod
+     * @return the APIMethod that was updated (note that it will NOT contain details of the replaced terms)
      * @throws AtlanException on any API problems
      */
-    public static APIObject replaceTerms(
+    public static APIMethod replaceTerms(
             AtlanClient client, String qualifiedName, String name, List<IGlossaryTerm> terms) throws AtlanException {
-        return (APIObject) Asset.replaceTerms(client, updater(qualifiedName, name), terms);
+        return (APIMethod) Asset.replaceTerms(client, updater(qualifiedName, name), terms);
     }
 
     /**
-     * Link additional terms to the APIObject, without replacing existing terms linked to the APIObject.
-     * Note: this operation must make two API calls — one to retrieve the APIObject's existing terms,
+     * Link additional terms to the APIMethod, without replacing existing terms linked to the APIMethod.
+     * Note: this operation must make two API calls — one to retrieve the APIMethod's existing terms,
      * and a second to append the new terms.
      *
-     * @param client connectivity to the Atlan tenant on which to append terms to the APIObject
-     * @param qualifiedName for the APIObject
-     * @param terms the list of terms to append to the APIObject
-     * @return the APIObject that was updated  (note that it will NOT contain details of the appended terms)
+     * @param client connectivity to the Atlan tenant on which to append terms to the APIMethod
+     * @param qualifiedName for the APIMethod
+     * @param terms the list of terms to append to the APIMethod
+     * @return the APIMethod that was updated  (note that it will NOT contain details of the appended terms)
      * @throws AtlanException on any API problems
      * @deprecated see {@link com.atlan.model.assets.Asset.AssetBuilder#appendAssignedTerm(GlossaryTerm)}
      */
     @Deprecated
-    public static APIObject appendTerms(AtlanClient client, String qualifiedName, List<IGlossaryTerm> terms)
+    public static APIMethod appendTerms(AtlanClient client, String qualifiedName, List<IGlossaryTerm> terms)
             throws AtlanException {
-        return (APIObject) Asset.appendTerms(client, TYPE_NAME, qualifiedName, terms);
+        return (APIMethod) Asset.appendTerms(client, TYPE_NAME, qualifiedName, terms);
     }
 
     /**
-     * Remove terms from a APIObject, without replacing all existing terms linked to the APIObject.
-     * Note: this operation must make two API calls — one to retrieve the APIObject's existing terms,
+     * Remove terms from a APIMethod, without replacing all existing terms linked to the APIMethod.
+     * Note: this operation must make two API calls — one to retrieve the APIMethod's existing terms,
      * and a second to remove the provided terms.
      *
-     * @param client connectivity to the Atlan tenant from which to remove terms from the APIObject
-     * @param qualifiedName for the APIObject
-     * @param terms the list of terms to remove from the APIObject, which must be referenced by GUID
-     * @return the APIObject that was updated (note that it will NOT contain details of the resulting terms)
+     * @param client connectivity to the Atlan tenant from which to remove terms from the APIMethod
+     * @param qualifiedName for the APIMethod
+     * @param terms the list of terms to remove from the APIMethod, which must be referenced by GUID
+     * @return the APIMethod that was updated (note that it will NOT contain details of the resulting terms)
      * @throws AtlanException on any API problems
      * @deprecated see {@link com.atlan.model.assets.Asset.AssetBuilder#removeAssignedTerm(GlossaryTerm)}
      */
     @Deprecated
-    public static APIObject removeTerms(AtlanClient client, String qualifiedName, List<IGlossaryTerm> terms)
+    public static APIMethod removeTerms(AtlanClient client, String qualifiedName, List<IGlossaryTerm> terms)
             throws AtlanException {
-        return (APIObject) Asset.removeTerms(client, TYPE_NAME, qualifiedName, terms);
+        return (APIMethod) Asset.removeTerms(client, TYPE_NAME, qualifiedName, terms);
     }
 
     /**
-     * Add Atlan tags to a APIObject, without replacing existing Atlan tags linked to the APIObject.
-     * Note: this operation must make two API calls — one to retrieve the APIObject's existing Atlan tags,
+     * Add Atlan tags to a APIMethod, without replacing existing Atlan tags linked to the APIMethod.
+     * Note: this operation must make two API calls — one to retrieve the APIMethod's existing Atlan tags,
      * and a second to append the new Atlan tags.
      *
-     * @param client connectivity to the Atlan tenant on which to append Atlan tags to the APIObject
-     * @param qualifiedName of the APIObject
+     * @param client connectivity to the Atlan tenant on which to append Atlan tags to the APIMethod
+     * @param qualifiedName of the APIMethod
      * @param atlanTagNames human-readable names of the Atlan tags to add
      * @throws AtlanException on any API problems
-     * @return the updated APIObject
+     * @return the updated APIMethod
      * @deprecated see {@link com.atlan.model.assets.Asset.AssetBuilder#appendAtlanTags(List)}
      */
     @Deprecated
-    public static APIObject appendAtlanTags(AtlanClient client, String qualifiedName, List<String> atlanTagNames)
+    public static APIMethod appendAtlanTags(AtlanClient client, String qualifiedName, List<String> atlanTagNames)
             throws AtlanException {
-        return (APIObject) Asset.appendAtlanTags(client, TYPE_NAME, qualifiedName, atlanTagNames);
+        return (APIMethod) Asset.appendAtlanTags(client, TYPE_NAME, qualifiedName, atlanTagNames);
     }
 
     /**
-     * Add Atlan tags to a APIObject, without replacing existing Atlan tags linked to the APIObject.
-     * Note: this operation must make two API calls — one to retrieve the APIObject's existing Atlan tags,
+     * Add Atlan tags to a APIMethod, without replacing existing Atlan tags linked to the APIMethod.
+     * Note: this operation must make two API calls — one to retrieve the APIMethod's existing Atlan tags,
      * and a second to append the new Atlan tags.
      *
-     * @param client connectivity to the Atlan tenant on which to append Atlan tags to the APIObject
-     * @param qualifiedName of the APIObject
+     * @param client connectivity to the Atlan tenant on which to append Atlan tags to the APIMethod
+     * @param qualifiedName of the APIMethod
      * @param atlanTagNames human-readable names of the Atlan tags to add
      * @param propagate whether to propagate the Atlan tag (true) or not (false)
      * @param removePropagationsOnDelete whether to remove the propagated Atlan tags when the Atlan tag is removed from this asset (true) or not (false)
      * @param restrictLineagePropagation whether to avoid propagating through lineage (true) or do propagate through lineage (false)
      * @throws AtlanException on any API problems
-     * @return the updated APIObject
+     * @return the updated APIMethod
      * @deprecated see {@link com.atlan.model.assets.Asset.AssetBuilder#appendAtlanTags(List, boolean, boolean, boolean, boolean)}
      */
     @Deprecated
-    public static APIObject appendAtlanTags(
+    public static APIMethod appendAtlanTags(
             AtlanClient client,
             String qualifiedName,
             List<String> atlanTagNames,
@@ -613,7 +611,7 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
             boolean removePropagationsOnDelete,
             boolean restrictLineagePropagation)
             throws AtlanException {
-        return (APIObject) Asset.appendAtlanTags(
+        return (APIMethod) Asset.appendAtlanTags(
                 client,
                 TYPE_NAME,
                 qualifiedName,
@@ -624,12 +622,12 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     }
 
     /**
-     * Remove an Atlan tag from a APIObject.
+     * Remove an Atlan tag from a APIMethod.
      *
-     * @param client connectivity to the Atlan tenant from which to remove an Atlan tag from a APIObject
-     * @param qualifiedName of the APIObject
+     * @param client connectivity to the Atlan tenant from which to remove an Atlan tag from a APIMethod
+     * @param qualifiedName of the APIMethod
      * @param atlanTagName human-readable name of the Atlan tag to remove
-     * @throws AtlanException on any API problems, or if the Atlan tag does not exist on the APIObject
+     * @throws AtlanException on any API problems, or if the Atlan tag does not exist on the APIMethod
      * @deprecated see {@link com.atlan.model.assets.Asset.AssetBuilder#removeAtlanTag(String)}
      */
     @Deprecated

--- a/sdk/src/main/java/com/atlan/model/assets/APIMethod.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIMethod.java
@@ -45,36 +45,155 @@ public class APIMethod extends Asset implements IAPIMethod, IAPI, ICatalog, IAss
     public static final String TYPE_NAME = "APIMethod";
 
     // Override all default methods that conflict between IAPI and ICatalog interfaces.
-    @Override public IApplication getApplication() { return null; }
-    @Override public IApplicationField getApplicationField() { return null; }
-    @Override public IDataContract getDataContractLatest() { return null; }
-    @Override public IDataContract getDataContractLatestCertified() { return null; }
-    @Override public IReadme getReadme() { return null; }
-    @Override public SortedSet<IAirflowTask> getInputToAirflowTasks() { return null; }
-    @Override public SortedSet<IAirflowTask> getOutputFromAirflowTasks() { return null; }
-    @Override public SortedSet<IAnomaloCheck> getAnomaloChecks() { return null; }
-    @Override public SortedSet<IAsset> getUserDefRelationshipFroms() { return null; }
-    @Override public SortedSet<IAsset> getUserDefRelationshipTos() { return null; }
-    @Override public SortedSet<IDataProduct> getInputPortDataProducts() { return null; }
-    @Override public SortedSet<IDataProduct> getOutputPortDataProducts() { return null; }
-    @Override public SortedSet<IDataQualityRule> getDqBaseDatasetRules() { return null; }
-    @Override public SortedSet<IDataQualityRule> getDqReferenceDatasetRules() { return null; }
-    @Override public SortedSet<IFile> getFiles() { return null; }
-    @Override public SortedSet<IGlossaryTerm> getAssignedTerms() { return null; }
-    @Override public SortedSet<ILineageProcess> getInputToProcesses() { return null; }
-    @Override public SortedSet<ILineageProcess> getOutputFromProcesses() { return null; }
-    @Override public SortedSet<ILink> getLinks() { return null; }
-    @Override public SortedSet<IMCIncident> getMcIncidents() { return null; }
-    @Override public SortedSet<IMCMonitor> getMcMonitors() { return null; }
-    @Override public SortedSet<IMetric> getMetrics() { return null; }
-    @Override public SortedSet<IModelAttribute> getModelImplementedAttributes() { return null; }
-    @Override public SortedSet<IModelEntity> getModelImplementedEntities() { return null; }
-    @Override public SortedSet<IPartialField> getPartialChildFields() { return null; }
-    @Override public SortedSet<IPartialObject> getPartialChildObjects() { return null; }
-    @Override public SortedSet<ISchemaRegistrySubject> getSchemaRegistrySubjects() { return null; }
-    @Override public SortedSet<ISodaCheck> getSodaChecks() { return null; }
-    @Override public SortedSet<ISparkJob> getInputToSparkJobs() { return null; }
-    @Override public SortedSet<ISparkJob> getOutputFromSparkJobs() { return null; }
+    @Override
+    public IApplication getApplication() {
+        return null;
+    }
+
+    @Override
+    public IApplicationField getApplicationField() {
+        return null;
+    }
+
+    @Override
+    public IDataContract getDataContractLatest() {
+        return null;
+    }
+
+    @Override
+    public IDataContract getDataContractLatestCertified() {
+        return null;
+    }
+
+    @Override
+    public IReadme getReadme() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IAirflowTask> getInputToAirflowTasks() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IAirflowTask> getOutputFromAirflowTasks() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IAnomaloCheck> getAnomaloChecks() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IAsset> getUserDefRelationshipFroms() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IAsset> getUserDefRelationshipTos() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IDataProduct> getInputPortDataProducts() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IDataProduct> getOutputPortDataProducts() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IDataQualityRule> getDqBaseDatasetRules() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IDataQualityRule> getDqReferenceDatasetRules() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IFile> getFiles() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IGlossaryTerm> getAssignedTerms() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<ILineageProcess> getInputToProcesses() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<ILineageProcess> getOutputFromProcesses() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<ILink> getLinks() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IMCIncident> getMcIncidents() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IMCMonitor> getMcMonitors() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IMetric> getMetrics() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IModelAttribute> getModelImplementedAttributes() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IModelEntity> getModelImplementedEntities() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IPartialField> getPartialChildFields() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<IPartialObject> getPartialChildObjects() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<ISchemaRegistrySubject> getSchemaRegistrySubjects() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<ISodaCheck> getSodaChecks() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<ISparkJob> getInputToSparkJobs() {
+        return null;
+    }
+
+    @Override
+    public SortedSet<ISparkJob> getOutputFromSparkJobs() {
+        return null;
+    }
 
     /** Fixed typeName for APIMethods. */
     @Getter(onMethod_ = {@Override})

--- a/sdk/src/main/java/com/atlan/model/assets/APIMethod.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIMethod.java
@@ -235,9 +235,17 @@ public class APIMethod extends Asset implements IAPIMethod, IAPI, ICatalog, IAss
     @Singular("apiMethodResponseSchema")
     SortedSet<IAPIObject> apiMethodResponseSchemas;
 
+    /** Unique name of the API method in which this asset exists. */
+    @Attribute
+    String apiMethodQualifiedName;
+
     /** Qualified name of the APIObject that is referred to by this asset. When apiIsObjectReference is true. */
     @Attribute
     String apiObjectQualifiedName;
+
+    /** Unique name of the API path in which this asset exists. */
+    @Attribute
+    String apiPathQualifiedName;
 
     /** API path on which this method operates. */
     @Attribute

--- a/sdk/src/main/java/com/atlan/model/assets/APIObject.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIObject.java
@@ -68,12 +68,12 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
 
     /** API methods that use this object as their request schema. */
     @Attribute
-    @Singular
+    @Singular("apiMethodRequestingThis")
     SortedSet<IAPIMethod> apiMethodsRequestingThis;
 
     /** API methods that use this object as one of their response schemas. */
     @Attribute
-    @Singular
+    @Singular("apiMethodRespondingWithThis")
     SortedSet<IAPIMethod> apiMethodsRespondingWithThis;
 
     /** If this asset refers to an APIObject */

--- a/sdk/src/main/java/com/atlan/model/assets/APIObject.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIObject.java
@@ -48,6 +48,10 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     @Builder.Default
     String typeName = TYPE_NAME;
 
+    /** Type of API body this object belongs to (e.g. "request", "response/200"). */
+    @Attribute
+    String apiBodyType;
+
     /** External documentation of the API. */
     @Attribute
     @Singular
@@ -71,6 +75,10 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     @Singular("apiMethodRequestingThis")
     SortedSet<IAPIMethod> apiMethodsRequestingThis;
 
+    /** Qualified name of the API method this object belongs to. */
+    @Attribute
+    String apiMethodQualifiedName;
+
     /** API methods that use this object as one of their response schemas. */
     @Attribute
     @Singular("apiMethodRespondingWithThis")
@@ -83,6 +91,10 @@ public class APIObject extends Asset implements IAPIObject, IAPI, ICatalog, IAss
     /** Qualified name of the APIObject that is referred to by this asset. When apiIsObjectReference is true. */
     @Attribute
     String apiObjectQualifiedName;
+
+    /** Qualified name of the API path this object belongs to. */
+    @Attribute
+    String apiPathQualifiedName;
 
     /** Simple name of the API spec, if this asset is contained in an API spec. */
     @Attribute

--- a/sdk/src/main/java/com/atlan/model/assets/APIPath.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIPath.java
@@ -65,6 +65,11 @@ public class APIPath extends Asset implements IAPIPath, IAPI, ICatalog, IAsset, 
     @Attribute
     String apiObjectQualifiedName;
 
+    /** API methods (operations) available on this path. */
+    @Attribute
+    @Singular
+    SortedSet<IAPIMethod> apiMethods;
+
     /** List of the operations available on the endpoint. */
     @Attribute
     @Singular

--- a/sdk/src/main/java/com/atlan/model/assets/APIPath.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APIPath.java
@@ -65,6 +65,10 @@ public class APIPath extends Asset implements IAPIPath, IAPI, ICatalog, IAsset, 
     @Attribute
     String apiObjectQualifiedName;
 
+    /** Unique name of the API path in which this asset exists. */
+    @Attribute
+    String apiPathQualifiedName;
+
     /** API methods (operations) available on this path. */
     @Attribute
     @Singular

--- a/sdk/src/main/java/com/atlan/model/assets/APISpec.java
+++ b/sdk/src/main/java/com/atlan/model/assets/APISpec.java
@@ -86,6 +86,10 @@ public class APISpec extends Asset implements IAPISpec, IAPI, ICatalog, IAsset, 
     @Attribute
     String apiSpecContractVersion;
 
+    /** Raw content of the API specification file (JSON or YAML). */
+    @Attribute
+    String apiSpecRawContent;
+
     /** Name of the license under which the API specification is available. */
     @Attribute
     String apiSpecLicenseName;

--- a/sdk/src/main/java/com/atlan/model/assets/IAPIField.java
+++ b/sdk/src/main/java/com/atlan/model/assets/IAPIField.java
@@ -42,6 +42,9 @@ public interface IAPIField {
 
     public static final String TYPE_NAME = "APIField";
 
+    /** Type of API body this field belongs to (e.g. "request", "response/200"). */
+    KeywordField API_BODY_TYPE = new KeywordField("apiBodyType", "apiBodyType");
+
     /** Type of APIField, as free text (e.g. STRING, NUMBER etc). */
     KeywordField API_FIELD_TYPE = new KeywordField("apiFieldType", "apiFieldType");
 
@@ -50,6 +53,12 @@ public interface IAPIField {
 
     /** APIObject asset containing this APIField. */
     RelationField API_OBJECT = new RelationField("apiObject");
+
+    /** Qualified name of the API method this field belongs to. */
+    KeywordField API_METHOD_QUALIFIED_NAME = new KeywordField("apiMethodQualifiedName", "apiMethodQualifiedName");
+
+    /** Qualified name of the API path this field belongs to. */
+    KeywordField API_PATH_QUALIFIED_NAME = new KeywordField("apiPathQualifiedName", "apiPathQualifiedName");
 
     /** APIQuery asset containing this APIField. */
     RelationField API_QUERY = new RelationField("apiQuery");
@@ -86,6 +95,9 @@ public interface IAPIField {
         return null;
     }
 
+    /** Type of API body this field belongs to (e.g. "request", "response/200"). */
+    String getApiBodyType();
+
     /** External documentation of the API. */
     Map<String, String> getApiExternalDocs();
 
@@ -101,6 +113,9 @@ public interface IAPIField {
     /** If this asset refers to an APIObject */
     Boolean getApiIsObjectReference();
 
+    /** Qualified name of the API method this field belongs to. */
+    String getApiMethodQualifiedName();
+
     /** APIObject asset containing this APIField. */
     default IAPIObject getApiObject() {
         return null;
@@ -108,6 +123,9 @@ public interface IAPIField {
 
     /** Qualified name of the APIObject that is referred to by this asset. When apiIsObjectReference is true. */
     String getApiObjectQualifiedName();
+
+    /** Qualified name of the API path this field belongs to. */
+    String getApiPathQualifiedName();
 
     /** APIQuery asset containing this APIField. */
     default IAPIQuery getApiQuery() {

--- a/sdk/src/main/java/com/atlan/model/assets/IAPIMethod.java
+++ b/sdk/src/main/java/com/atlan/model/assets/IAPIMethod.java
@@ -31,8 +31,7 @@ public interface IAPIMethod {
     TextField API_METHOD_RESPONSE = new TextField("apiMethodResponse", "apiMethodResponse");
 
     /** Map of HTTP response status codes to the qualified names of the APIObject schemas that describe each response. */
-    KeywordField API_METHOD_RESPONSE_CODES =
-            new KeywordField("apiMethodResponseCodes", "apiMethodResponseCodes");
+    KeywordField API_METHOD_RESPONSE_CODES = new KeywordField("apiMethodResponseCodes", "apiMethodResponseCodes");
 
     /** APIObject schema describing this method's request body. */
     RelationField API_METHOD_REQUEST_SCHEMA = new RelationField("apiMethodRequestSchema");

--- a/sdk/src/main/java/com/atlan/model/assets/IAPIMethod.java
+++ b/sdk/src/main/java/com/atlan/model/assets/IAPIMethod.java
@@ -2,6 +2,7 @@
    Copyright 2023 Atlan Pte. Ltd. */
 package com.atlan.model.assets;
 
+import com.atlan.model.fields.KeywordField;
 import com.atlan.model.fields.RelationField;
 import com.atlan.model.fields.TextField;
 import com.atlan.serde.AssetDeserializer;
@@ -28,6 +29,10 @@ public interface IAPIMethod {
 
     /** Response body or schema information for this API method. */
     TextField API_METHOD_RESPONSE = new TextField("apiMethodResponse", "apiMethodResponse");
+
+    /** Map of HTTP response status codes to the qualified names of the APIObject schemas that describe each response. */
+    KeywordField API_METHOD_RESPONSE_CODES =
+            new KeywordField("apiMethodResponseCodes", "apiMethodResponseCodes");
 
     /** APIObject schema describing this method's request body. */
     RelationField API_METHOD_REQUEST_SCHEMA = new RelationField("apiMethodRequestSchema");

--- a/sdk/src/main/java/com/atlan/model/assets/IAPIMethod.java
+++ b/sdk/src/main/java/com/atlan/model/assets/IAPIMethod.java
@@ -1,0 +1,64 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2023 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import com.atlan.model.fields.RelationField;
+import com.atlan.model.fields.TextField;
+import com.atlan.serde.AssetDeserializer;
+import com.atlan.serde.AssetSerializer;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.Map;
+import java.util.SortedSet;
+import javax.annotation.processing.Generated;
+
+/**
+ * Instance of an API method (operation) on a path in Atlan.
+ * Represents a single HTTP method such as GET, POST, PUT, DELETE on an APIPath.
+ */
+@Generated(value = "com.atlan.generators.ModelGeneratorV2")
+@JsonSerialize(using = AssetSerializer.class)
+@JsonDeserialize(using = AssetDeserializer.class)
+public interface IAPIMethod {
+
+    public static final String TYPE_NAME = "APIMethod";
+
+    /** Request body or schema information for this API method. */
+    TextField API_METHOD_REQUEST = new TextField("apiMethodRequest", "apiMethodRequest");
+
+    /** Response body or schema information for this API method. */
+    TextField API_METHOD_RESPONSE = new TextField("apiMethodResponse", "apiMethodResponse");
+
+    /** APIObject schema describing this method's request body. */
+    RelationField API_METHOD_REQUEST_SCHEMA = new RelationField("apiMethodRequestSchema");
+
+    /** APIObject schemas describing this method's response bodies. */
+    RelationField API_METHOD_RESPONSE_SCHEMAS = new RelationField("apiMethodResponseSchemas");
+
+    /** API path on which this method operates. */
+    RelationField API_PATH = new RelationField("apiPath");
+
+    /** Request body or schema information for this API method. */
+    String getApiMethodRequest();
+
+    /** Response body or schema information for this API method. */
+    String getApiMethodResponse();
+
+    /** Map of HTTP response status codes to the qualified names of the APIObject schemas that describe each response. */
+    Map<String, String> getApiMethodResponseCodes();
+
+    /** APIObject schema describing this method's request body. */
+    default IAPIObject getApiMethodRequestSchema() {
+        return null;
+    }
+
+    /** APIObject schemas describing this method's response bodies. */
+    default SortedSet<IAPIObject> getApiMethodResponseSchemas() {
+        return null;
+    }
+
+    /** API path on which this method operates. */
+    default IAPIPath getApiPath() {
+        return null;
+    }
+}

--- a/sdk/src/main/java/com/atlan/model/assets/IAPIObject.java
+++ b/sdk/src/main/java/com/atlan/model/assets/IAPIObject.java
@@ -44,6 +44,12 @@ public interface IAPIObject {
     /** Count of the APIField of this object. */
     NumericField API_FIELD_COUNT = new NumericField("apiFieldCount", "apiFieldCount");
 
+    /** API methods that use this object as their request schema. */
+    RelationField API_METHODS_REQUESTING_THIS = new RelationField("apiMethodsRequestingThis");
+
+    /** API methods that use this object as one of their response schemas. */
+    RelationField API_METHODS_RESPONDING_WITH_THIS = new RelationField("apiMethodsRespondingWithThis");
+
     /** APIField assets contained within this APIObject. */
     RelationField API_FIELDS = new RelationField("apiFields");
 
@@ -89,6 +95,16 @@ public interface IAPIObject {
 
     /** Whether authentication is optional (true) or required (false). */
     Boolean getApiIsAuthOptional();
+
+    /** API methods that use this object as their request schema. */
+    default SortedSet<IAPIMethod> getApiMethodsRequestingThis() {
+        return null;
+    }
+
+    /** API methods that use this object as one of their response schemas. */
+    default SortedSet<IAPIMethod> getApiMethodsRespondingWithThis() {
+        return null;
+    }
 
     /** If this asset refers to an APIObject */
     Boolean getApiIsObjectReference();

--- a/sdk/src/main/java/com/atlan/model/assets/IAPIObject.java
+++ b/sdk/src/main/java/com/atlan/model/assets/IAPIObject.java
@@ -13,6 +13,7 @@ import com.atlan.model.enums.DataQualityResult;
 import com.atlan.model.enums.DataQualityScheduleType;
 import com.atlan.model.enums.DataQualitySourceSyncStatus;
 import com.atlan.model.enums.SourceCostUnitType;
+import com.atlan.model.fields.KeywordField;
 import com.atlan.model.fields.NumericField;
 import com.atlan.model.fields.RelationField;
 import com.atlan.model.relations.RelationshipAttributes;
@@ -41,6 +42,9 @@ public interface IAPIObject {
 
     public static final String TYPE_NAME = "APIObject";
 
+    /** Type of API body this object belongs to (e.g. "request", "response/200"). */
+    KeywordField API_BODY_TYPE = new KeywordField("apiBodyType", "apiBodyType");
+
     /** Count of the APIField of this object. */
     NumericField API_FIELD_COUNT = new NumericField("apiFieldCount", "apiFieldCount");
 
@@ -52,6 +56,12 @@ public interface IAPIObject {
 
     /** APIField assets contained within this APIObject. */
     RelationField API_FIELDS = new RelationField("apiFields");
+
+    /** Qualified name of the API method this object belongs to. */
+    KeywordField API_METHOD_QUALIFIED_NAME = new KeywordField("apiMethodQualifiedName", "apiMethodQualifiedName");
+
+    /** Qualified name of the API path this object belongs to. */
+    KeywordField API_PATH_QUALIFIED_NAME = new KeywordField("apiPathQualifiedName", "apiPathQualifiedName");
 
     /** List of groups who administer this asset. (This is only used for certain asset types.) */
     SortedSet<String> getAdminGroups();
@@ -82,6 +92,9 @@ public interface IAPIObject {
         return null;
     }
 
+    /** Type of API body this object belongs to (e.g. "request", "response/200"). */
+    String getApiBodyType();
+
     /** External documentation of the API. */
     Map<String, String> getApiExternalDocs();
 
@@ -101,6 +114,9 @@ public interface IAPIObject {
         return null;
     }
 
+    /** Qualified name of the API method this object belongs to. */
+    String getApiMethodQualifiedName();
+
     /** API methods that use this object as one of their response schemas. */
     default SortedSet<IAPIMethod> getApiMethodsRespondingWithThis() {
         return null;
@@ -111,6 +127,9 @@ public interface IAPIObject {
 
     /** Qualified name of the APIObject that is referred to by this asset. When apiIsObjectReference is true. */
     String getApiObjectQualifiedName();
+
+    /** Qualified name of the API path this object belongs to. */
+    String getApiPathQualifiedName();
 
     /** Simple name of the API spec, if this asset is contained in an API spec. */
     String getApiSpecName();

--- a/sdk/src/main/java/com/atlan/model/assets/IAPIPath.java
+++ b/sdk/src/main/java/com/atlan/model/assets/IAPIPath.java
@@ -64,6 +64,9 @@ public interface IAPIPath {
     /** Descriptive summary intended to apply to all operations in this path. */
     TextField API_PATH_SUMMARY = new TextField("apiPathSummary", "apiPathSummary");
 
+    /** API methods (operations) available on this path. */
+    RelationField API_METHODS = new RelationField("apiMethods");
+
     /** API specification in which this path exists. */
     RelationField API_SPEC = new RelationField("apiSpec");
 
@@ -107,6 +110,11 @@ public interface IAPIPath {
 
     /** Qualified name of the APIObject that is referred to by this asset. When apiIsObjectReference is true. */
     String getApiObjectQualifiedName();
+
+    /** API methods (operations) available on this path. */
+    default SortedSet<IAPIMethod> getApiMethods() {
+        return null;
+    }
 
     /** List of the operations available on the endpoint. */
     SortedSet<String> getApiPathAvailableOperations();

--- a/sdk/src/main/java/com/atlan/model/assets/IAPISpec.java
+++ b/sdk/src/main/java/com/atlan/model/assets/IAPISpec.java
@@ -72,6 +72,9 @@ public interface IAPISpec {
     KeywordTextField API_SPEC_SERVICE_ALIAS =
             new KeywordTextField("apiSpecServiceAlias", "apiSpecServiceAlias", "apiSpecServiceAlias.text");
 
+    /** Raw content of the API specification file (JSON or YAML). */
+    KeywordField API_SPEC_RAW_CONTENT = new KeywordField("apiSpecRawContent", "apiSpecRawContent");
+
     /** URL to the terms of service for the API specification. */
     KeywordTextField API_SPEC_TERMS_OF_SERVICE_URL = new KeywordTextField(
             "apiSpecTermsOfServiceURL", "apiSpecTermsOfServiceURL", "apiSpecTermsOfServiceURL.text");

--- a/sdk/src/main/java/com/atlan/model/assets/_overlays/APIMethod.java
+++ b/sdk/src/main/java/com/atlan/model/assets/_overlays/APIMethod.java
@@ -1,0 +1,34 @@
+    /**
+     * Builds the minimal object necessary to create an API method.
+     *
+     * @param httpMethod the HTTP method (e.g. GET, POST, PUT, DELETE) for this API method
+     * @param apiPath in which the API method should be created, which must have at least
+     *                a qualifiedName
+     * @return the minimal request necessary to create the API method, as a builder
+     * @throws InvalidRequestException if the apiPath provided is without a qualifiedName
+     */
+    public static APIMethodBuilder<?, ?> creator(String httpMethod, APIPath apiPath) throws InvalidRequestException {
+        Map<String, String> map = new HashMap<>();
+        map.put("qualifiedName", apiPath.getQualifiedName());
+        validateRelationship(APIPath.TYPE_NAME, map);
+        return creator(httpMethod, apiPath.getQualifiedName()).apiPath(apiPath.trimToReference());
+    }
+
+    /**
+     * Builds the minimal object necessary to create an API method.
+     *
+     * @param httpMethod the HTTP method (e.g. GET, POST, PUT, DELETE) for this API method
+     * @param apiPathQualifiedName unique name of the API path on which this method operates
+     * @return the minimal object necessary to create the API method, as a builder
+     */
+    public static APIMethodBuilder<?, ?> creator(String httpMethod, String apiPathQualifiedName) {
+        String connectionQualifiedName = StringUtils.getParentQualifiedNameFromQualifiedName(
+                StringUtils.getParentQualifiedNameFromQualifiedName(apiPathQualifiedName));
+        String normalizedMethod = httpMethod.toUpperCase();
+        return APIMethod._internal()
+                .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
+                .qualifiedName(apiPathQualifiedName + "/" + normalizedMethod)
+                .name(normalizedMethod)
+                .apiPath(APIPath.refByQualifiedName(apiPathQualifiedName))
+                .connectionQualifiedName(connectionQualifiedName);
+    }


### PR DESCRIPTION
## Summary (EPD-268 / PRDLNCH-5559)

Adds the **APIMethod** Java SDK type and enhances the OpenAPI Spec loader to create APIMethod, APIObject, and APIField entities with full relationship wiring.

### Key changes
- **APIMethod SDK type**: new entity with relationships to APIPath (parent) and APIObject (request/response schemas)
- **Loader: inline schema support**: resolves `$ref`, inline objects, arrays, and primitives into physical APIObject/APIField hierarchies
- **Loader: example payloads**: `generateExample()` and `generatePrimitiveExample()` produce JSON example blobs per response body
- **Loader: shell APIObjects**: created for primitive and no-content responses so every method has a body entity
- **Loader: relationship fix**: method↔object relationships created via `POST /api/meta/relationship` REST API to work around SDK-Atlas attribute name mismatch (SDK field names are cross-wired relative to Atlas typedef end definitions)
- **Simplified `resolveFieldType()`**: no format suffix; description always set to clear stale values

### Commits
1. `5a43e19` — Add APIMethod, APIObject, APIField creation to OpenAPI Spec loader
2. `48f6f85` — Add APIMethod Java SDK type with relationships
3. `265eb89` — Fix compilation errors in APIMethod and APIObject SDK types
4. `da7f171` — Apply Spotless formatting to loader source files
5. `6011872` — Add inline schema support and expand test coverage
6. `4b38617` — Apply Spotless formatting to APIMethod SDK files
7. `123317d` — Example payloads, relationship REST API fix, shell objects

## Test plan
- [ ] Loader creates APIMethod entities under each APIPath
- [ ] Request/response body APIObjects created per-method (not shared)
- [ ] Relationships visible via Atlas search (`apiMethodsRespondingWithThis`, `apiMethodsRequestingThis`)
- [ ] Shell APIObjects created for primitive/no-content responses
- [ ] Example payloads populated on response body blobs
- [ ] Re-run after purging soft-deleted entities produces clean state

🤖 Generated with [Claude Code](https://claude.com/claude-code)