### PR TITLE
fix(tests): remove overly strict updatedAssets assertions from delete/purge tests

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/ADLSAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/ADLSAssetTest.java
@@ -227,7 +227,6 @@ public class ADLSAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, object.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof ADLSObject);
@@ -264,7 +263,6 @@ public class ADLSAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, object.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof ADLSObject);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/APIAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/APIAssetTest.java
@@ -175,7 +175,6 @@ public class APIAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, path.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof APIPath);
@@ -212,7 +211,6 @@ public class APIAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, path.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof APIPath);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/AirflowAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/AirflowAssetTest.java
@@ -195,7 +195,6 @@ public class AirflowAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, task.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof AirflowTask);
@@ -232,7 +231,6 @@ public class AirflowAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, task.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof AirflowTask);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/AnaplanAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/AnaplanAssetTest.java
@@ -491,7 +491,6 @@ public class AnaplanAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, list.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof AnaplanList);
@@ -528,7 +527,6 @@ public class AnaplanAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, list.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof AnaplanList);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/AppAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/AppAssetTest.java
@@ -192,7 +192,6 @@ public class AppAssetTest extends AtlanLiveTest {
                 Asset.delete(client, applicationField.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof ApplicationField);
@@ -230,7 +229,6 @@ public class AppAssetTest extends AtlanLiveTest {
                 Asset.purge(client, applicationField.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof ApplicationField);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/AzureEventHubTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/AzureEventHubTest.java
@@ -227,7 +227,6 @@ public class AzureEventHubTest extends AtlanLiveTest {
                 Asset.delete(client, consumerGroup.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof AzureEventHubConsumerGroup);
@@ -265,7 +264,6 @@ public class AzureEventHubTest extends AtlanLiveTest {
                 Asset.purge(client, consumerGroup.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof AzureEventHubConsumerGroup);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/CustomAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/CustomAssetTest.java
@@ -217,7 +217,6 @@ public class CustomAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, child2.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof CustomEntity);
@@ -254,7 +253,6 @@ public class CustomAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, child2.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof CustomEntity);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/CustomMetadataTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/CustomMetadataTest.java
@@ -1387,7 +1387,6 @@ public class CustomMetadataTest extends AtlanLiveTest {
             AssetMutationResponse response = Asset.delete(client, guid);
             assertNotNull(response);
             assertEquals(response.getCreatedAssets().size(), 0);
-            assertEquals(response.getUpdatedAssets().size(), 0);
             List<Asset> entities = response.getDeletedAssets();
             assertNotNull(entities);
         }

--- a/integration-tests/src/test/java/com/atlan/java/sdk/DataStudioAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/DataStudioAssetTest.java
@@ -179,7 +179,6 @@ public class DataStudioAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, source.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof DataStudioAsset);
@@ -216,7 +215,6 @@ public class DataStudioAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, source.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof DataStudioAsset);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/DataverseAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/DataverseAssetTest.java
@@ -175,7 +175,6 @@ public class DataverseAssetTest extends AtlanLiveTest {
                 Asset.delete(client, attribute.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof DataverseAttribute);
@@ -213,7 +212,6 @@ public class DataverseAssetTest extends AtlanLiveTest {
                 Asset.purge(client, attribute.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof DataverseAttribute);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/FileTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/FileTest.java
@@ -151,7 +151,6 @@ public class FileTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, file.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof File);
@@ -188,7 +187,6 @@ public class FileTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, file.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof File);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/GCSAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/GCSAssetTest.java
@@ -192,7 +192,6 @@ public class GCSAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, object.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof GCSObject);
@@ -229,7 +228,6 @@ public class GCSAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, object.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof GCSObject);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/GlossaryTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/GlossaryTest.java
@@ -156,7 +156,6 @@ public class GlossaryTest extends AtlanLiveTest {
         AssetMutationResponse response = Glossary.purge(client, guid).block();
         assertNotNull(response);
         assertEquals(response.getCreatedAssets().size(), 0);
-        assertEquals(response.getUpdatedAssets().size(), 0);
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof Glossary);
@@ -178,7 +177,6 @@ public class GlossaryTest extends AtlanLiveTest {
         AssetMutationResponse response = GlossaryCategory.purge(client, guid).block();
         assertNotNull(response);
         assertEquals(response.getCreatedAssets().size(), 0);
-        assertEquals(response.getUpdatedAssets().size(), 0);
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof GlossaryCategory);
@@ -201,7 +199,6 @@ public class GlossaryTest extends AtlanLiveTest {
         AssetMutationResponse response = GlossaryTerm.purge(client, guid).block();
         assertNotNull(response);
         assertEquals(response.getCreatedAssets().size(), 0);
-        assertEquals(response.getUpdatedAssets().size(), 0);
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof GlossaryTerm);
@@ -749,7 +746,6 @@ public class GlossaryTest extends AtlanLiveTest {
                 GlossaryTerm.delete(client, term1.getGuid()).block();
         assertNotNull(response);
         assertEquals(response.getCreatedAssets().size(), 0);
-        assertEquals(response.getUpdatedAssets().size(), 0);
         List<Asset> entities = response.getDeletedAssets();
         assertNotNull(entities);
         assertEquals(entities.size(), 1);
@@ -892,7 +888,6 @@ public class GlossaryTest extends AtlanLiveTest {
                 .block();
         assertNotNull(response);
         assertEquals(response.getCreatedAssets().size(), 0);
-        assertEquals(response.getUpdatedAssets().size(), 0);
         List<Asset> entities = response.getDeletedAssets();
         assertNotNull(entities);
         assertEquals(entities.size(), 7);
@@ -902,7 +897,6 @@ public class GlossaryTest extends AtlanLiveTest {
                 .block();
         assertNotNull(response);
         assertEquals(response.getCreatedAssets().size(), 0);
-        assertEquals(response.getUpdatedAssets().size(), 0);
         entities = response.getDeletedAssets();
         assertNotNull(entities);
         assertEquals(entities.size(), 4);
@@ -912,7 +906,6 @@ public class GlossaryTest extends AtlanLiveTest {
                 .block();
         assertNotNull(response);
         assertEquals(response.getCreatedAssets().size(), 0);
-        assertEquals(response.getUpdatedAssets().size(), 0);
         entities = response.getDeletedAssets();
         assertNotNull(entities);
         assertEquals(entities.size(), 2);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/InsightsTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/InsightsTest.java
@@ -321,7 +321,6 @@ public class InsightsTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, query.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof AtlanQuery);
@@ -358,7 +357,6 @@ public class InsightsTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, query.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof AtlanQuery);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/KafkaTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/KafkaTest.java
@@ -228,7 +228,6 @@ public class KafkaTest extends AtlanLiveTest {
                 Asset.delete(client, consumerGroup.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof KafkaConsumerGroup);
@@ -266,7 +265,6 @@ public class KafkaTest extends AtlanLiveTest {
                 Asset.purge(client, consumerGroup.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof KafkaConsumerGroup);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/PresetAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/PresetAssetTest.java
@@ -278,7 +278,6 @@ public class PresetAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, chart.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof PresetChart);
@@ -315,7 +314,6 @@ public class PresetAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, chart.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof PresetChart);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/S3AssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/S3AssetTest.java
@@ -354,7 +354,6 @@ public class S3AssetTest extends AtlanLiveTest {
                 Asset.delete(client, objectARN.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof S3Object);
@@ -373,7 +372,6 @@ public class S3AssetTest extends AtlanLiveTest {
                 Asset.delete(client, objectByName.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof S3Object);
@@ -430,7 +428,6 @@ public class S3AssetTest extends AtlanLiveTest {
                 Asset.purge(client, objectARN.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof S3Object);
@@ -449,7 +446,6 @@ public class S3AssetTest extends AtlanLiveTest {
                 Asset.purge(client, objectByName.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof S3Object);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/SQLAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/SQLAssetTest.java
@@ -1815,7 +1815,6 @@ public class SQLAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, column5.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof Column);
@@ -1850,7 +1849,6 @@ public class SQLAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, column5.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof Column);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/SupersetAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/SupersetAssetTest.java
@@ -243,7 +243,6 @@ public class SupersetAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.delete(client, chart.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof SupersetChart);
@@ -280,7 +279,6 @@ public class SupersetAssetTest extends AtlanLiveTest {
         AssetMutationResponse response = Asset.purge(client, chart.getGuid()).block();
         assertNotNull(response);
         assertTrue(response.getCreatedAssets().isEmpty());
-        assertTrue(response.getUpdatedAssets().isEmpty());
         assertEquals(response.getDeletedAssets().size(), 1);
         Asset one = response.getDeletedAssets().get(0);
         assertTrue(one instanceof SupersetChart);

--- a/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java
@@ -314,7 +314,6 @@ public class TableSearchTest extends AtlanLiveTest {
             AssetMutationResponse response = Asset.delete(client, guid);
             assertNotNull(response);
             assertEquals(response.getCreatedAssets().size(), 0);
-            assertEquals(response.getUpdatedAssets().size(), 0);
             List<Asset> entities = response.getDeletedAssets();
             assertNotNull(entities);
         }


### PR DESCRIPTION
## Summary

- The Atlan backend started returning cascading side-effected assets in the `UPDATE` bucket of delete responses around April 10, 2026 (e.g. parent glossary appears in `updatedAssets` when a child term is soft-deleted)
- Removed `assertTrue(response.getUpdatedAssets().isEmpty())` and `assertEquals(response.getUpdatedAssets().size(), 0)` assertions from all delete/purge test methods across 20 test files
- Retained these assertions in create-operation methods where they remain valid (GlossaryTest, ConnectionTest, PersonaTest, PurposeTest, AtlanLiveTest, ModelTest)
- The meaningful delete-success signals — `getDeletedAssets().size()`, asset GUID/qualifiedName, status `DELETED`, and deleteHandler — are all preserved

Fixes: BLDX-1041

## Test plan

- [ ] Integration tests should now pass for all delete/purge methods that were previously failing with `AssertionError: expected [true] but found [false]`
- [ ] Create-operation assertions remain unchanged and unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)