### PR TITLE
fix(tests): fix integration test assertions broken by server-side response format changes

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/CustomMetadataTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/CustomMetadataTest.java
@@ -347,6 +347,7 @@ public class CustomMetadataTest extends AtlanLiveTest {
         assertTrue(response.getCreatedAssets().get(0) instanceof Badge);
         badge1 = (Badge) response.getCreatedAssets().get(0);
         assertNotNull(badge1.getGuid());
+        badge1 = Badge.get(client, badge1.getGuid(), true);
         List<BadgeCondition> badgeConditions = badge1.getBadgeConditions();
         assertEquals(badgeConditions.size(), 3);
         // Badges may come back in a different order in the response...
@@ -382,6 +383,7 @@ public class CustomMetadataTest extends AtlanLiveTest {
         assertTrue(response.getCreatedAssets().get(0) instanceof Badge);
         badge2 = (Badge) response.getCreatedAssets().get(0);
         assertNotNull(badge2.getGuid());
+        badge2 = Badge.get(client, badge2.getGuid(), true);
         badgeConditions = badge2.getBadgeConditions();
         assertEquals(badgeConditions.size(), 4);
         for (BadgeCondition condition : badgeConditions) {
@@ -402,6 +404,7 @@ public class CustomMetadataTest extends AtlanLiveTest {
         assertTrue(response.getCreatedAssets().get(0) instanceof Badge);
         badge3 = (Badge) response.getCreatedAssets().get(0);
         assertNotNull(badge3.getGuid());
+        badge3 = Badge.get(client, badge3.getGuid(), true);
         badgeConditions = badge3.getBadgeConditions();
         assertEquals(badgeConditions.size(), 1);
         assertEquals(badgeConditions.get(0).getBadgeConditionOperator(), BadgeComparisonOperator.EQ);
@@ -419,6 +422,7 @@ public class CustomMetadataTest extends AtlanLiveTest {
         assertTrue(response.getCreatedAssets().get(0) instanceof Badge);
         badge4 = (Badge) response.getCreatedAssets().get(0);
         assertNotNull(badge4.getGuid());
+        badge4 = Badge.get(client, badge4.getGuid(), true);
         badgeConditions = badge4.getBadgeConditions();
         assertEquals(badgeConditions.size(), 2);
         for (BadgeCondition condition : badgeConditions) {

--- a/integration-tests/src/test/java/com/atlan/java/sdk/LineageTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/LineageTest.java
@@ -93,31 +93,25 @@ public class LineageTest extends AtlanLiveTest {
         assertNotNull(start.getGuid());
         assertNotNull(start.getQualifiedName());
         assertEquals(start.getName(), processName);
-        assertNotNull(start.getInputs());
-        assertEquals(start.getInputs().size(), 1);
-        for (ICatalog input : start.getInputs()) {
+        Set<String> guids =
+                response.getUpdatedAssets().stream().map(Asset::getGuid).collect(Collectors.toSet());
+        assertTrue(guids.contains(table.getGuid()));
+        assertTrue(guids.contains(mview.getGuid()));
+        LineageProcess startReadBack = LineageProcess.get(client, start.getGuid(), true);
+        assertNotNull(startReadBack.getInputs());
+        assertEquals(startReadBack.getInputs().size(), 1);
+        for (ICatalog input : startReadBack.getInputs()) {
             assertNotNull(input);
             assertEquals(input.getTypeName(), Table.TYPE_NAME);
             assertEquals(input.getGuid(), table.getGuid());
         }
-        assertNotNull(start.getOutputs());
-        assertEquals(start.getOutputs().size(), 1);
-        for (ICatalog output : start.getOutputs()) {
+        assertNotNull(startReadBack.getOutputs());
+        assertEquals(startReadBack.getOutputs().size(), 1);
+        for (ICatalog output : startReadBack.getOutputs()) {
             assertNotNull(output);
             assertEquals(output.getTypeName(), MaterializedView.TYPE_NAME);
             assertEquals(output.getGuid(), mview.getGuid());
         }
-        assertEquals(response.getUpdatedAssets().size(), 2);
-        Set<String> types =
-                response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet());
-        assertEquals(types.size(), 2);
-        assertTrue(types.contains(Table.TYPE_NAME));
-        assertTrue(types.contains(MaterializedView.TYPE_NAME));
-        Set<String> guids =
-                response.getUpdatedAssets().stream().map(Asset::getGuid).collect(Collectors.toSet());
-        assertEquals(guids.size(), 2);
-        assertTrue(guids.contains(table.getGuid()));
-        assertTrue(guids.contains(mview.getGuid()));
     }
 
     @Test(
@@ -142,31 +136,25 @@ public class LineageTest extends AtlanLiveTest {
         assertNotNull(end.getGuid());
         assertNotNull(end.getQualifiedName());
         assertEquals(end.getName(), processName);
-        assertNotNull(end.getInputs());
-        assertEquals(end.getInputs().size(), 1);
-        for (ICatalog input : end.getInputs()) {
+        Set<String> guids =
+                response.getUpdatedAssets().stream().map(Asset::getGuid).collect(Collectors.toSet());
+        assertTrue(guids.contains(mview.getGuid()));
+        assertTrue(guids.contains(view.getGuid()));
+        LineageProcess endReadBack = LineageProcess.get(client, end.getGuid(), true);
+        assertNotNull(endReadBack.getInputs());
+        assertEquals(endReadBack.getInputs().size(), 1);
+        for (ICatalog input : endReadBack.getInputs()) {
             assertNotNull(input);
             assertEquals(input.getTypeName(), MaterializedView.TYPE_NAME);
             assertEquals(input.getGuid(), mview.getGuid());
         }
-        assertNotNull(end.getOutputs());
-        assertEquals(end.getOutputs().size(), 1);
-        for (ICatalog output : end.getOutputs()) {
+        assertNotNull(endReadBack.getOutputs());
+        assertEquals(endReadBack.getOutputs().size(), 1);
+        for (ICatalog output : endReadBack.getOutputs()) {
             assertNotNull(output);
             assertEquals(output.getTypeName(), View.TYPE_NAME);
             assertEquals(output.getGuid(), view.getGuid());
         }
-        assertEquals(response.getUpdatedAssets().size(), 2);
-        Set<String> types =
-                response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet());
-        assertEquals(types.size(), 2);
-        assertTrue(types.contains(MaterializedView.TYPE_NAME));
-        assertTrue(types.contains(View.TYPE_NAME));
-        Set<String> guids =
-                response.getUpdatedAssets().stream().map(Asset::getGuid).collect(Collectors.toSet());
-        assertEquals(guids.size(), 2);
-        assertTrue(guids.contains(mview.getGuid()));
-        assertTrue(guids.contains(view.getGuid()));
     }
 
     @Test(

--- a/integration-tests/src/test/java/com/atlan/java/sdk/PersonaTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/PersonaTest.java
@@ -78,7 +78,8 @@ public class PersonaTest extends AtlanLiveTest {
         Persona found = (Persona) one;
         assertEquals(found.getGuid(), persona.getGuid());
         assertEquals(found.getDescription(), "Now with a description!");
-        assertEquals(found.getDenyAssetTabs().size(), 3);
+        Persona readBack = Persona.get(client, persona.getQualifiedName(), true);
+        assertEquals(readBack.getDenyAssetTabs().size(), 3);
     }
 
     @Test(

--- a/integration-tests/src/test/java/com/atlan/java/sdk/PurposeTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/PurposeTest.java
@@ -140,7 +140,8 @@ public class PurposeTest extends AtlanLiveTest {
         Purpose found = (Purpose) one;
         assertEquals(found.getGuid(), purpose.getGuid());
         assertEquals(found.getDescription(), "Now with a description!");
-        assertEquals(found.getDenyAssetTabs().size(), 3);
+        Purpose readBack = Purpose.get(client, purpose.getQualifiedName(), true);
+        assertEquals(readBack.getDenyAssetTabs().size(), 3);
     }
 
     @Test(
@@ -344,9 +345,7 @@ public class PurposeTest extends AtlanLiveTest {
         Column toUpdate = Column.updater(columnQualifiedName, COLUMN_NAME)
                 .removeAtlanTag(ATLAN_TAG_NAME)
                 .build();
-        AssetMutationResponse response = client.assets.save(toUpdate);
-        assertNotNull(response);
-        validateSingleUpdate(response);
+        client.assets.save(toUpdate);
         // Column.removeAtlanTag(client, columnQualifiedName, ATLAN_TAG_NAME);
         AtlanTagTest.deleteAtlanTag(client, ATLAN_TAG_NAME);
     }


### PR DESCRIPTION
## Summary

- Removes overly strict `updatedAssets.isEmpty()` / `updatedAssets.size() == 0` assertions from all delete/purge test methods — the Atlan backend now returns cascading side-effected assets in the `UPDATE` bucket of delete responses (server-side change ~April 10, 2026)
- Fixes tests that asserted on nested relationship attributes (`inputs`/`outputs`, `denyAssetTabs`, `badgeConditions`) directly from mutation responses — these are no longer eagerly populated by the server; tests now do an explicit read-back to validate them
- Relaxes strict `updatedAssets` count assertions in lineage tests to GUID-presence checks, since the server may return additional cascading updates

Fixes: BLDX-1041

## Changed tests

**Delete/purge assertions (45 lines removed across 20 files):**
ADLSAssetTest, APIAssetTest, AirflowAssetTest, AnaplanAssetTest, AppAssetTest, AzureEventHubTest, CustomAssetTest, CustomMetadataTest, DataStudioAssetTest, DataverseAssetTest, FileTest, GCSAssetTest, GlossaryTest, InsightsTest, KafkaTest, PresetAssetTest, S3AssetTest, SQLAssetTest, SupersetAssetTest, TableSearchTest

**Read-back fixes:**
- `LineageTest.createLineageStart/End` — `LineageProcess.get(guid, true)` to verify `inputs`/`outputs`
- `PersonaTest.updatePersonas` — `Persona.get(qualifiedName, true)` to verify `denyAssetTabs`
- `PurposeTest.updatePurposes` — `Purpose.get(qualifiedName, true)` to verify `denyAssetTabs`
- `PurposeTest.purgeAtlanTags` — removed `validateSingleUpdate` (cleanup step, no response assertion needed)
- `CustomMetadataTest.createBadges` — `Badge.get(guid, true)` for each of 4 badges to verify `badgeConditions`

## Test plan

- [ ] All previously failing delete/purge tests should pass (no more `expected [true] but found [false]` on empty updatedAssets)
- [ ] LineageTest, PersonaTest, PurposeTest, CustomMetadataTest should pass with read-back validation
- [ ] Create-operation assertions (ConnectionTest, AtlanLiveTest, ModelTest, PersonaTest.createPersonas, PurposeTest.createPurposes) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)