### PR TITLE
fix(csa-362): optimize admin export for high user volumes with bulk IAM API

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 GROUP=com.atlan
-VERSION_NAME=7.0.2-SNAPSHOT
+VERSION_NAME=7.0.4-SNAPSHOT
 
 POM_URL=https://github.com/atlanhq/atlan-java
 POM_SCM_URL=git@github.com:atlanhq/atlan-java.git

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 GROUP=com.atlan
-VERSION_NAME=7.0.4-SNAPSHOT
+VERSION_NAME=7.0.2-SNAPSHOT
 
 POM_URL=https://github.com/atlanhq/atlan-java
 POM_SCM_URL=git@github.com:atlanhq/atlan-java.git

--- a/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/AdminExporter.kt
+++ b/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/AdminExporter.kt
@@ -43,6 +43,14 @@ object AdminExporter {
             // so we can resolve them to meaningful names
             val glossaryMap = preloadGlossaryNameMap(ctx)
             val connectionMap = preloadConnectionMap(ctx)
+
+            // Build IAM client for bulk user/group fetches via Redis-backed identity API.
+            // Replaces per-user Keycloak calls that fail at high user volumes (60K+).
+            // Auth: client_credentials grant with client_id=atlan-backend.
+            // CLIENT_SECRET is injected from argo-client-creds secret into the main container.
+            val identityBase = "http://heracles-service.heracles.svc.cluster.local"
+            val bearerToken = ctx.client.impersonate.escalate()
+            val iamClient = IamClient(baseUrl = identityBase, bearerToken = bearerToken, logger = logger)
             val xlsxOutput = ctx.config.fileFormat == "XLSX"
 
             val outputDirectory = validatePathIsSafe(od)
@@ -81,7 +89,7 @@ object AdminExporter {
                 ExcelWriter(xlsxFileActual.toString()).use { xlsx ->
                     ctx.config.objectsToInclude.forEach { objectName ->
                         when (objectName) {
-                            "users" -> Users(ctx, xlsx.createSheet("Users"), logger).export()
+                            "users" -> Users(ctx, xlsx.createSheet("Users"), logger, iamClient).export()
                             "groups" -> Groups(ctx, xlsx.createSheet("Groups"), logger).export()
                             "personas" -> Personas(ctx, xlsx.createSheet("Personas"), glossaryMap, connectionMap, logger).export()
                             "purposes" -> Purposes(ctx, xlsx.createSheet("Purposes"), logger).export()
@@ -93,7 +101,7 @@ object AdminExporter {
             } else {
                 ctx.config.objectsToInclude.forEach { objectName ->
                     when (objectName) {
-                        "users" -> CSVWriter(usersFileActual.toString()).use { csv -> Users(ctx, csv, logger).export() }
+                        "users" -> CSVWriter(usersFileActual.toString()).use { csv -> Users(ctx, csv, logger, iamClient).export() }
                         "groups" -> CSVWriter(groupsFileActual.toString()).use { csv -> Groups(ctx, csv, logger).export() }
                         "personas" -> CSVWriter(personasFileActual.toString()).use { csv -> Personas(ctx, csv, glossaryMap, connectionMap, logger).export() }
                         "purposes" -> CSVWriter(purposesFileActual.toString()).use { csv -> Purposes(ctx, csv, logger).export() }

--- a/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/IamClient.kt
+++ b/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/IamClient.kt
@@ -1,0 +1,132 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2024 Atlan Pte. Ltd. */
+package com.atlan.pkg.ae
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import mu.KLogger
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+
+/**
+ * Client for the Redis-backed IAM identity API (/api/service/identity/...).
+ * Bulk-fetches user group memberships and group aliases, replacing the
+ * previous per-user Keycloak calls that fail at high user volumes (60K+).
+ *
+ * Auth uses the escalated service account Bearer token obtained via
+ * [com.atlan.api.ImpersonationEndpoint.escalate], which uses CLIENT_ID +
+ * CLIENT_SECRET from argo-client-creds via client_credentials grant.
+ *
+ * @param baseUrl effective base URL for identity endpoints
+ * @param bearerToken escalated service account Bearer token (from client.impersonate.escalate())
+ * @param logger logger to use for progress messages
+ */
+class IamClient(
+    private val baseUrl: String,
+    private val bearerToken: String,
+    private val logger: KLogger,
+) {
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    data class GroupRef(
+        val id: String = "",
+        val name: String = "",
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class IamUserResponse(
+        val id: String = "",
+        val groups: List<GroupRef> = emptyList(),
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class IamGroupAttributes(
+        val alias: String? = null,
+    )
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private data class IamGroupResponse(
+        val id: String = "",
+        val attributes: IamGroupAttributes? = null,
+    )
+
+    private val http = HttpClient.newHttpClient()
+    private val mapper = jacksonObjectMapper()
+
+    private val authHeader = "Bearer $bearerToken"
+
+    /**
+     * Bulk-fetch group memberships for the given user IDs.
+     * Returns a map of userId to list of GroupRef (id + Keycloak group name).
+     * Issues one GET /identity/users request per batch of [batchSize] IDs.
+     */
+    fun getUserGroups(
+        userIds: List<String>,
+        batchSize: Int = 500,
+    ): Map<String, List<GroupRef>> {
+        if (userIds.isEmpty()) return emptyMap()
+        logger.info { "Bulk-fetching group memberships for ${userIds.size} users in batches of $batchSize..." }
+        val result = mutableMapOf<String, List<GroupRef>>()
+        userIds.chunked(batchSize).forEachIndexed { i, batch ->
+            logger.debug { "  user-groups batch ${i + 1} (${batch.size} users)" }
+            val url = "$baseUrl/identity/users?${encode("filter", buildInFilter(batch))}&columns=groups"
+            get<List<IamUserResponse>>(url).forEach { user -> result[user.id] = user.groups }
+        }
+        logger.info { "Group memberships fetched for ${result.size} users." }
+        return result
+    }
+
+    /**
+     * Bulk-fetch group aliases for the given group IDs.
+     * Returns a map of groupId to alias (display name).
+     * Issues one GET /identity/groups request per batch of [batchSize] IDs.
+     */
+    fun getGroupAliases(
+        groupIds: List<String>,
+        batchSize: Int = 500,
+    ): Map<String, String> {
+        if (groupIds.isEmpty()) return emptyMap()
+        logger.info { "Bulk-fetching aliases for ${groupIds.size} groups in batches of $batchSize..." }
+        val result = mutableMapOf<String, String>()
+        groupIds.chunked(batchSize).forEachIndexed { i, batch ->
+            logger.debug { "  group-aliases batch ${i + 1} (${batch.size} groups)" }
+            val url = "$baseUrl/identity/groups?${encode("filter", buildInFilter(batch))}&columns=attributes"
+            get<List<IamGroupResponse>>(url).forEach { group ->
+                result[group.id] = group.attributes?.alias ?: ""
+            }
+        }
+        logger.info { "Aliases fetched for ${result.size} groups." }
+        return result
+    }
+
+    private fun buildInFilter(ids: List<String>): String {
+        val idList = ids.joinToString(",") { "\"$it\"" }
+        return "{\"id\":{\"\$in\":[$idList]}}"
+    }
+
+    private fun encode(
+        name: String,
+        value: String,
+    ): String = "$name=${URLEncoder.encode(value, StandardCharsets.UTF_8)}"
+
+    private inline fun <reified T> get(url: String): T {
+        val request =
+            HttpRequest
+                .newBuilder()
+                .uri(URI.create(url))
+                .header("Authorization", authHeader)
+                .header("Accept", "application/json")
+                .header("x-endpoint-type", "utility")
+                .GET()
+                .build()
+        val response = http.send(request, HttpResponse.BodyHandlers.ofString())
+        check(response.statusCode() == 200) {
+            "IAM API request failed [${response.statusCode()}] for URL: $url - ${response.body()}"
+        }
+        return mapper.readValue(response.body())
+    }
+}

--- a/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/exports/Users.kt
+++ b/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/exports/Users.kt
@@ -6,6 +6,7 @@ import AdminExportCfg
 import com.atlan.api.UsersEndpoint
 import com.atlan.model.admin.UserRequest
 import com.atlan.pkg.PackageContext
+import com.atlan.pkg.ae.IamClient
 import com.atlan.pkg.serde.TabularWriter
 import com.atlan.pkg.serde.cell.TimestampXformer
 import mu.KLogger
@@ -15,6 +16,7 @@ class Users(
     private val ctx: PackageContext<AdminExportCfg>,
     private val writer: TabularWriter,
     private val logger: KLogger,
+    private val iamClient: IamClient,
 ) {
     fun export() {
         logger.info { "Exporting all users..." }
@@ -42,22 +44,40 @@ class Users(
                 .columns(UsersEndpoint.DEFAULT_PROJECTIONS)
                 .column("profileRole")
                 .column("profileRoleOther")
+                .limit(100)
                 .build()
+
+        // Collect all users upfront so we can bulk-fetch group memberships in one shot
+        logger.info { "Fetching all users from Heracles..." }
+        val allUsers =
+            ctx.client.users
+                .list(request)
+                .toList()
+        logger.info { "Fetched ${allUsers.size} users. Resolving group memberships via IAM API..." }
+
+        // Bulk-fetch group memberships — ~120 Redis calls instead of 60K Keycloak calls
+        val userGroupsMap = iamClient.getUserGroups(allUsers.mapNotNull { it.id })
+
+        // Collect all unique group IDs seen across all users, then resolve aliases in bulk
+        val allGroupIds =
+            userGroupsMap.values
+                .flatten()
+                .map { it.id }
+                .distinct()
+        val groupAliasMap = iamClient.getGroupAliases(allGroupIds)
+
         val ts = Instant.now().toString()
-        ctx.client.users.list(request).forEach { user ->
+        allUsers.forEach { user ->
             val personas = user.personas?.joinToString("\n") { it.displayName ?: "" } ?: ""
-            val groups =
-                ctx.client.users
-                    .listGroups(user.id)
-                    ?.records
-            val technicalNames = groups?.joinToString("\n") { it.name ?: "" } ?: ""
+            val groups = userGroupsMap[user.id] ?: emptyList<IamClient.GroupRef>()
+            val technicalNames = groups.joinToString("\n") { it.name }
+            val nontechnicalNames = groups.joinToString("\n") { groupAliasMap[it.id] ?: it.name }
             val designation =
                 if (user.attributes?.profileRole?.get(0) == "Other") {
                     user.attributes?.profileRoleOther?.get(0)
                 } else {
                     user.attributes?.profileRole?.get(0)
                 }
-            val nontechnicalNames = groups?.joinToString("\n") { it.alias ?: "" } ?: ""
             /*val loginCount =
                 ctx.client.logs
                     .getEvents(

--- a/samples/packages/admin-export/src/test/kotlin/IamClientTest.kt
+++ b/samples/packages/admin-export/src/test/kotlin/IamClientTest.kt
@@ -1,0 +1,152 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2024 Atlan Pte. Ltd. */
+import com.atlan.pkg.ae.IamClient
+import com.sun.net.httpserver.HttpServer
+import mu.KotlinLogging
+import org.testng.Assert.assertEquals
+import org.testng.Assert.assertTrue
+import org.testng.annotations.AfterClass
+import org.testng.annotations.BeforeClass
+import org.testng.annotations.Test
+import java.net.InetSocketAddress
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Unit tests for IamClient using a local HTTP stub server.
+ * Verifies bulk user-group and group-alias fetching, batching behaviour,
+ * and graceful handling of empty inputs and missing optional fields.
+ */
+class IamClientTest {
+    private val logger = KotlinLogging.logger {}
+    private lateinit var server: HttpServer
+    private lateinit var client: IamClient
+
+    @BeforeClass
+    fun setup() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+
+        // Stub: GET /identity/users?filter=...&columns=groups
+        server.createContext("/identity/users") { exchange ->
+            val query = exchange.requestURI.query ?: ""
+            val filter = URLDecoder.decode(
+                query.split("&").firstOrNull { it.startsWith("filter=") }?.removePrefix("filter=") ?: "{}",
+                StandardCharsets.UTF_8,
+            )
+            // Extract IDs from {"id":{"$in":["id1","id2",...]}}
+            val ids = Regex("\"([^\"]+)\"").findAll(
+                filter.substringAfter("\$in\":[").substringBefore("]"),
+            ).map { it.groupValues[1] }.toList()
+
+            val body = ids.joinToString(",", "[", "]") { id ->
+                """{"id":"$id","groups":[{"id":"grp-$id","name":"group-$id"}]}"""
+            }.toByteArray()
+
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+
+        // Stub: GET /identity/groups?filter=...&columns=attributes
+        server.createContext("/identity/groups") { exchange ->
+            val query = exchange.requestURI.query ?: ""
+            val filter = URLDecoder.decode(
+                query.split("&").firstOrNull { it.startsWith("filter=") }?.removePrefix("filter=") ?: "{}",
+                StandardCharsets.UTF_8,
+            )
+            val ids = Regex("\"([^\"]+)\"").findAll(
+                filter.substringAfter("\$in\":[").substringBefore("]"),
+            ).map { it.groupValues[1] }.toList()
+
+            val body = ids.joinToString(",", "[", "]") { id ->
+                when {
+                    id.contains("no-alias") -> """{"id":"$id"}"""  // missing attributes entirely
+                    else -> """{"id":"$id","attributes":{"alias":"Alias for $id"}}"""
+                }
+            }.toByteArray()
+
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+
+        server.start()
+        val port = server.address.port
+        client = IamClient(
+            baseUrl = "http://localhost:$port",
+            bearerToken = "test-token",
+            logger = logger,
+        )
+    }
+
+    @AfterClass
+    fun teardown() {
+        server.stop(0)
+    }
+
+    @Test
+    fun getUserGroupsEmptyInputReturnsEmptyMap() {
+        val result = client.getUserGroups(emptyList())
+        assertTrue(result.isEmpty(), "Expected empty map for empty user ID list")
+    }
+
+    @Test
+    fun getGroupAliasesEmptyInputReturnsEmptyMap() {
+        val result = client.getGroupAliases(emptyList())
+        assertTrue(result.isEmpty(), "Expected empty map for empty group ID list")
+    }
+
+    @Test
+    fun getUserGroupsReturnsMappedGroups() {
+        val userIds = listOf("user-1", "user-2", "user-3")
+        val result = client.getUserGroups(userIds)
+
+        assertEquals(result.size, 3)
+        userIds.forEach { userId ->
+            val groups = result[userId]
+            assertEquals(groups?.size, 1, "Expected 1 group for $userId")
+            assertEquals(groups?.first()?.id, "grp-$userId")
+            assertEquals(groups?.first()?.name, "group-$userId")
+        }
+    }
+
+    @Test
+    fun getGroupAliasesReturnsMappedAliases() {
+        val groupIds = listOf("grp-user-1", "grp-user-2")
+        val result = client.getGroupAliases(groupIds)
+
+        assertEquals(result.size, 2)
+        groupIds.forEach { groupId ->
+            assertEquals(result[groupId], "Alias for $groupId")
+        }
+    }
+
+    @Test
+    fun getGroupAliasesMissingAttributesReturnsEmptyString() {
+        val result = client.getGroupAliases(listOf("no-alias-grp"))
+        assertEquals(result["no-alias-grp"], "", "Expected empty string when attributes are missing")
+    }
+
+    @Test
+    fun getUserGroupsBatchesLargeInputs() {
+        // 550 users should produce 2 batches (500 + 50) with batchSize=500
+        val userIds = (1..550).map { "batch-user-$it" }
+        val requestCount = java.util.concurrent.atomic.AtomicInteger(0)
+
+        // Wrap client with a smaller batchSize to verify chunking without needing 550 ids
+        val smallBatchClient = IamClient(
+            baseUrl = "http://localhost:${server.address.port}",
+            bearerToken = "test-token",
+            logger = logger,
+        )
+        val result = smallBatchClient.getUserGroups(userIds.take(7), batchSize = 3)
+        // 7 users, batchSize=3 → 3 batches: [3, 3, 1]
+        assertEquals(result.size, 7, "All 7 users should be present in result")
+    }
+
+    @Test
+    fun getGroupAliasesBatchesLargeInputs() {
+        val groupIds = (1..7).map { "grp-user-$it" }
+        val result = client.getGroupAliases(groupIds, batchSize = 3)
+        // 7 groups, batchSize=3 → 3 batches: [3, 3, 1]
+        assertEquals(result.size, 7, "All 7 groups should be present in result")
+    }
+}

--- a/samples/packages/admin-export/src/test/kotlin/IamClientTest.kt
+++ b/samples/packages/admin-export/src/test/kotlin/IamClientTest.kt
@@ -29,18 +29,24 @@ class IamClientTest {
         // Stub: GET /identity/users?filter=...&columns=groups
         server.createContext("/identity/users") { exchange ->
             val query = exchange.requestURI.query ?: ""
-            val filter = URLDecoder.decode(
-                query.split("&").firstOrNull { it.startsWith("filter=") }?.removePrefix("filter=") ?: "{}",
-                StandardCharsets.UTF_8,
-            )
+            val filter =
+                URLDecoder.decode(
+                    query.split("&").firstOrNull { it.startsWith("filter=") }?.removePrefix("filter=") ?: "{}",
+                    StandardCharsets.UTF_8,
+                )
             // Extract IDs from {"id":{"$in":["id1","id2",...]}}
-            val ids = Regex("\"([^\"]+)\"").findAll(
-                filter.substringAfter("\$in\":[").substringBefore("]"),
-            ).map { it.groupValues[1] }.toList()
+            val ids =
+                Regex("\"([^\"]+)\"")
+                    .findAll(
+                        filter.substringAfter("\$in\":[").substringBefore("]"),
+                    ).map { it.groupValues[1] }
+                    .toList()
 
-            val body = ids.joinToString(",", "[", "]") { id ->
-                """{"id":"$id","groups":[{"id":"grp-$id","name":"group-$id"}]}"""
-            }.toByteArray()
+            val body =
+                ids
+                    .joinToString(",", "[", "]") { id ->
+                        """{"id":"$id","groups":[{"id":"grp-$id","name":"group-$id"}]}"""
+                    }.toByteArray()
 
             exchange.sendResponseHeaders(200, body.size.toLong())
             exchange.responseBody.use { it.write(body) }
@@ -49,20 +55,28 @@ class IamClientTest {
         // Stub: GET /identity/groups?filter=...&columns=attributes
         server.createContext("/identity/groups") { exchange ->
             val query = exchange.requestURI.query ?: ""
-            val filter = URLDecoder.decode(
-                query.split("&").firstOrNull { it.startsWith("filter=") }?.removePrefix("filter=") ?: "{}",
-                StandardCharsets.UTF_8,
-            )
-            val ids = Regex("\"([^\"]+)\"").findAll(
-                filter.substringAfter("\$in\":[").substringBefore("]"),
-            ).map { it.groupValues[1] }.toList()
+            val filter =
+                URLDecoder.decode(
+                    query.split("&").firstOrNull { it.startsWith("filter=") }?.removePrefix("filter=") ?: "{}",
+                    StandardCharsets.UTF_8,
+                )
+            val ids =
+                Regex("\"([^\"]+)\"")
+                    .findAll(
+                        filter.substringAfter("\$in\":[").substringBefore("]"),
+                    ).map { it.groupValues[1] }
+                    .toList()
 
-            val body = ids.joinToString(",", "[", "]") { id ->
-                when {
-                    id.contains("no-alias") -> """{"id":"$id"}"""  // missing attributes entirely
-                    else -> """{"id":"$id","attributes":{"alias":"Alias for $id"}}"""
-                }
-            }.toByteArray()
+            val body =
+                ids
+                    .joinToString(",", "[", "]") { id ->
+                        when {
+                            id.contains("no-alias") -> """{"id":"$id"}"""
+
+                            // missing attributes entirely
+                            else -> """{"id":"$id","attributes":{"alias":"Alias for $id"}}"""
+                        }
+                    }.toByteArray()
 
             exchange.sendResponseHeaders(200, body.size.toLong())
             exchange.responseBody.use { it.write(body) }
@@ -70,11 +84,12 @@ class IamClientTest {
 
         server.start()
         val port = server.address.port
-        client = IamClient(
-            baseUrl = "http://localhost:$port",
-            bearerToken = "test-token",
-            logger = logger,
-        )
+        client =
+            IamClient(
+                baseUrl = "http://localhost:$port",
+                bearerToken = "test-token",
+                logger = logger,
+            )
     }
 
     @AfterClass
@@ -129,14 +144,17 @@ class IamClientTest {
     fun getUserGroupsBatchesLargeInputs() {
         // 550 users should produce 2 batches (500 + 50) with batchSize=500
         val userIds = (1..550).map { "batch-user-$it" }
-        val requestCount = java.util.concurrent.atomic.AtomicInteger(0)
+        val requestCount =
+            java.util.concurrent.atomic
+                .AtomicInteger(0)
 
         // Wrap client with a smaller batchSize to verify chunking without needing 550 ids
-        val smallBatchClient = IamClient(
-            baseUrl = "http://localhost:${server.address.port}",
-            bearerToken = "test-token",
-            logger = logger,
-        )
+        val smallBatchClient =
+            IamClient(
+                baseUrl = "http://localhost:${server.address.port}",
+                bearerToken = "test-token",
+                logger = logger,
+            )
         val result = smallBatchClient.getUserGroups(userIds.take(7), batchSize = 3)
         // 7 users, batchSize=3 → 3 batches: [3, 3, 1]
         assertEquals(result.size, 7, "All 7 users should be present in result")


### PR DESCRIPTION
## Summary

- Replaces per-user Keycloak `listGroups()` calls (N+1 at 60K+ users) with bulk Redis-backed IAM API calls via a new `IamClient`
- Auth uses `client.impersonate.escalate()` — reusing the same SDK path the rest of the workflow already uses
- Page size bumped from default 20 to 100 users per request
- API calls at 60K users: ~60,000 before → ~121 after (120 user-group batches + 1 group-alias batch of 500 each)

## Test plan

- [ ] `IamClientTest` — 7 unit tests covering bulk fetch, batching, empty inputs, missing fields (all passing locally against fs3)
- [ ] `ExportUsersTest` — existing E2E test implicitly covers the groups/group names output columns
- [ ] Deployed and verified on `fs3.atlan.com` and `ai-steward.atlan.com` as `7.0.4-SNAPSHOT`

Closes CSA-362