### PR TITLE
fix(csa-362): optimize admin export for high user volumes with bulk IAM API

### DIFF
--- a/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/AdminExporter.kt
+++ b/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/AdminExporter.kt
@@ -43,6 +43,7 @@ object AdminExporter {
             // so we can resolve them to meaningful names
             val glossaryMap = preloadGlossaryNameMap(ctx)
             val connectionMap = preloadConnectionMap(ctx)
+
             val xlsxOutput = ctx.config.fileFormat == "XLSX"
 
             val outputDirectory = validatePathIsSafe(od)

--- a/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/exports/Users.kt
+++ b/samples/packages/admin-export/src/main/kotlin/com/atlan/pkg/ae/exports/Users.kt
@@ -4,6 +4,7 @@ package com.atlan.pkg.ae.exports
 
 import AdminExportCfg
 import com.atlan.api.UsersEndpoint
+import com.atlan.model.admin.IamGroupRef
 import com.atlan.model.admin.UserRequest
 import com.atlan.pkg.PackageContext
 import com.atlan.pkg.serde.TabularWriter
@@ -42,22 +43,41 @@ class Users(
                 .columns(UsersEndpoint.DEFAULT_PROJECTIONS)
                 .column("profileRole")
                 .column("profileRoleOther")
+                .limit(100)
                 .build()
+
+        // Collect all users upfront so we can bulk-fetch group memberships in one shot
+        logger.info { "Fetching all users from Heracles..." }
+        val allUsers =
+            ctx.client.users
+                .list(request)
+                .toList()
+        logger.info { "Fetched ${allUsers.size} users. Resolving group memberships via IAM API..." }
+
+        // Bulk-fetch group memberships — ~120 Redis calls instead of 60K Keycloak calls
+        logger.info { "Resolving group memberships via IdentityEndpoint (bulk IAM API)..." }
+        val userGroupsMap = ctx.client.identity.getUserGroups(allUsers.mapNotNull { it.id })
+
+        // Collect all unique group IDs seen across all users, then resolve aliases in bulk
+        val allGroupIds =
+            userGroupsMap.values
+                .flatten()
+                .map { it.id }
+                .distinct()
+        val groupAliasMap = ctx.client.identity.getGroupAliases(allGroupIds)
+
         val ts = Instant.now().toString()
-        ctx.client.users.list(request).forEach { user ->
+        allUsers.forEach { user ->
             val personas = user.personas?.joinToString("\n") { it.displayName ?: "" } ?: ""
-            val groups =
-                ctx.client.users
-                    .listGroups(user.id)
-                    ?.records
-            val technicalNames = groups?.joinToString("\n") { it.name ?: "" } ?: ""
+            val groups = userGroupsMap[user.id] ?: emptyList<IamGroupRef>()
+            val technicalNames = groups.joinToString("\n") { it.name }
+            val nontechnicalNames = groups.joinToString("\n") { groupAliasMap[it.id] ?: it.name }
             val designation =
                 if (user.attributes?.profileRole?.get(0) == "Other") {
                     user.attributes?.profileRoleOther?.get(0)
                 } else {
                     user.attributes?.profileRole?.get(0)
                 }
-            val nontechnicalNames = groups?.joinToString("\n") { it.alias ?: "" } ?: ""
             /*val loginCount =
                 ctx.client.logs
                     .getEvents(

--- a/samples/packages/admin-export/src/test/kotlin/IamClientTest.kt
+++ b/samples/packages/admin-export/src/test/kotlin/IamClientTest.kt
@@ -1,0 +1,141 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2024 Atlan Pte. Ltd. */
+import com.atlan.api.IdentityEndpoint
+import com.sun.net.httpserver.HttpServer
+import org.testng.Assert.assertEquals
+import org.testng.Assert.assertTrue
+import org.testng.annotations.AfterClass
+import org.testng.annotations.BeforeClass
+import org.testng.annotations.Test
+import java.net.InetSocketAddress
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+/**
+ * Unit tests for IdentityEndpoint using a local HTTP stub server.
+ * Verifies bulk user-group and group-alias fetching, batching behaviour,
+ * and graceful handling of empty inputs and missing optional fields.
+ */
+class IamClientTest {
+    private lateinit var server: HttpServer
+    private lateinit var endpoint: IdentityEndpoint
+
+    @BeforeClass
+    fun setup() {
+        server = HttpServer.create(InetSocketAddress(0), 0)
+
+        // Stub: GET /identity/users?filter=...&columns=groups
+        server.createContext("/identity/users") { exchange ->
+            val query = exchange.requestURI.query ?: ""
+            val filter =
+                URLDecoder.decode(
+                    query.split("&").firstOrNull { it.startsWith("filter=") }?.removePrefix("filter=") ?: "{}",
+                    StandardCharsets.UTF_8,
+                )
+            val ids =
+                Regex("\"([^\"]+)\"")
+                    .findAll(filter.substringAfter("\$in\":[").substringBefore("]"))
+                    .map { it.groupValues[1] }
+                    .toList()
+            val body =
+                ids
+                    .joinToString(",", "[", "]") { id ->
+                        """{"id":"$id","groups":[{"id":"grp-$id","name":"group-$id"}]}"""
+                    }.toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+
+        // Stub: GET /identity/groups?filter=...&columns=attributes
+        server.createContext("/identity/groups") { exchange ->
+            val query = exchange.requestURI.query ?: ""
+            val filter =
+                URLDecoder.decode(
+                    query.split("&").firstOrNull { it.startsWith("filter=") }?.removePrefix("filter=") ?: "{}",
+                    StandardCharsets.UTF_8,
+                )
+            val ids =
+                Regex("\"([^\"]+)\"")
+                    .findAll(filter.substringAfter("\$in\":[").substringBefore("]"))
+                    .map { it.groupValues[1] }
+                    .toList()
+            val body =
+                ids
+                    .joinToString(",", "[", "]") { id ->
+                        if (id.contains("no-alias")) {
+                            """{"id":"$id"}"""
+                        } else {
+                            """{"id":"$id","attributes":{"alias":"Alias for $id"}}"""
+                        }
+                    }.toByteArray()
+            exchange.sendResponseHeaders(200, body.size.toLong())
+            exchange.responseBody.use { it.write(body) }
+        }
+
+        server.start()
+        val port = server.address.port
+        endpoint = IdentityEndpoint.forTesting("http://localhost:$port", "test-token")
+    }
+
+    @AfterClass
+    fun teardown() {
+        server.stop(0)
+    }
+
+    @Test
+    fun getUserGroupsEmptyInputReturnsEmptyMap() {
+        val result = endpoint.getUserGroups(emptyList())
+        assertTrue(result.isEmpty(), "Expected empty map for empty user ID list")
+    }
+
+    @Test
+    fun getGroupAliasesEmptyInputReturnsEmptyMap() {
+        val result = endpoint.getGroupAliases(emptyList())
+        assertTrue(result.isEmpty(), "Expected empty map for empty group ID list")
+    }
+
+    @Test
+    fun getUserGroupsReturnsMappedGroups() {
+        val userIds = listOf("user-1", "user-2", "user-3")
+        val result = endpoint.getUserGroups(userIds)
+        assertEquals(result.size, 3)
+        userIds.forEach { userId ->
+            val groups = result[userId]
+            assertEquals(groups?.size, 1, "Expected 1 group for $userId")
+            assertEquals(groups?.first()?.id, "grp-$userId")
+            assertEquals(groups?.first()?.name, "group-$userId")
+        }
+    }
+
+    @Test
+    fun getGroupAliasesReturnsMappedAliases() {
+        val groupIds = listOf("grp-user-1", "grp-user-2")
+        val result = endpoint.getGroupAliases(groupIds)
+        assertEquals(result.size, 2)
+        groupIds.forEach { groupId ->
+            assertEquals(result[groupId], "Alias for $groupId")
+        }
+    }
+
+    @Test
+    fun getGroupAliasesMissingAttributesReturnsEmptyString() {
+        val result = endpoint.getGroupAliases(listOf("no-alias-grp"))
+        assertEquals(result["no-alias-grp"], "", "Expected empty string when attributes are missing")
+    }
+
+    @Test
+    fun getUserGroupsBatchesLargeInputs() {
+        // 7 users with batchSize=3 → 3 batches: [3, 3, 1]
+        val userIds = (1..7).map { "user-$it" }
+        val result = endpoint.getUserGroups(userIds, 3)
+        assertEquals(result.size, 7, "All 7 users should be present in result")
+    }
+
+    @Test
+    fun getGroupAliasesBatchesLargeInputs() {
+        // 7 groups with batchSize=3 → 3 batches: [3, 3, 1]
+        val groupIds = (1..7).map { "grp-user-$it" }
+        val result = endpoint.getGroupAliases(groupIds, 3)
+        assertEquals(result.size, 7, "All 7 groups should be present in result")
+    }
+}

--- a/sdk/src/main/java/com/atlan/AtlanClient.java
+++ b/sdk/src/main/java/com/atlan/AtlanClient.java
@@ -189,6 +189,9 @@ public class AtlanClient implements AtlanCloseable {
     /** Endpoint with operations to interact with data contracts. */
     public final ContractsEndpoint contracts;
 
+    /** Endpoint with operations to interact with the Redis-backed IAM identity service. */
+    public final IdentityEndpoint identity;
+
     /** Client-aware asset deserializer. */
     @Getter
     private final AssetDeserializer assetDeserializer;
@@ -336,6 +339,7 @@ public class AtlanClient implements AtlanCloseable {
         sso = new SSOEndpoint(this);
         openLineage = new OpenLineageEndpoint(this);
         contracts = new ContractsEndpoint(this);
+        identity = new IdentityEndpoint(this);
         atlanTagCache = new AtlanTagCache(this);
         customMetadataCache = new CustomMetadataCache(this);
         enumCache = new EnumCache(typeDefs);

--- a/sdk/src/main/java/com/atlan/api/IdentityEndpoint.java
+++ b/sdk/src/main/java/com/atlan/api/IdentityEndpoint.java
@@ -1,0 +1,218 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2024 Atlan Pte. Ltd. */
+package com.atlan.api;
+
+import com.atlan.AtlanClient;
+import com.atlan.exception.ApiConnectionException;
+import com.atlan.exception.ApiException;
+import com.atlan.exception.AtlanException;
+import com.atlan.exception.ErrorCode;
+import com.atlan.model.admin.IamGroupRef;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.Getter;
+
+/**
+ * API endpoints for the Redis-backed IAM identity service (/identity/...).
+ * Provides bulk lookups for user group memberships and group aliases,
+ * replacing per-user Keycloak calls that fail at high user volumes.
+ */
+public class IdentityEndpoint extends HeraclesEndpoint {
+
+    private static final String USERS_ENDPOINT = "/identity/users";
+    private static final String GROUPS_ENDPOINT = "/identity/groups";
+    private static final int DEFAULT_BATCH_SIZE = 500;
+
+    private final HttpClient http = HttpClient.newHttpClient();
+
+    // Cached once per instance — workflows are short-lived
+    private volatile String cachedToken = null;
+
+    // Set only in test instances to override production base URL and JSON mapper
+    private final String testBaseUrl;
+    private final ObjectMapper testMapper;
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class IamUserResponse {
+        String id;
+        List<IamGroupRef> groups;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class IamGroupAttributes {
+        String alias;
+    }
+
+    @Getter
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class IamGroupResponse {
+        String id;
+        IamGroupAttributes attributes;
+    }
+
+    /** Production constructor — wired in via AtlanClient. */
+    public IdentityEndpoint(AtlanClient client) {
+        super(client);
+        this.testBaseUrl = null;
+        this.testMapper = null;
+    }
+
+    /** Test-only constructor — bypasses AtlanClient and Keycloak token fetch. */
+    private IdentityEndpoint(String testBaseUrl, String bearerToken) {
+        super(null);
+        this.testBaseUrl = testBaseUrl;
+        this.testMapper = new ObjectMapper();
+        this.cachedToken = bearerToken;
+    }
+
+    /**
+     * Creates a test instance that routes all identity calls to the given base URL
+     * and uses the supplied bearer token, without requiring a live AtlanClient.
+     *
+     * @param baseUrl base URL of the stub server (e.g. "http://localhost:8080")
+     * @param bearerToken token to use in the Authorization header
+     * @return a test-configured IdentityEndpoint
+     */
+    public static IdentityEndpoint forTesting(String baseUrl, String bearerToken) {
+        return new IdentityEndpoint(baseUrl, bearerToken);
+    }
+
+    @Override
+    protected String getBaseUrl() throws ApiConnectionException {
+        return testBaseUrl != null ? testBaseUrl : super.getBaseUrl();
+    }
+
+    private String getAuthToken() throws AtlanException {
+        if (cachedToken == null) {
+            cachedToken = client.impersonate.escalate();
+        }
+        return "Bearer " + cachedToken;
+    }
+
+    /**
+     * Bulk-fetch group memberships for the given user IDs.
+     *
+     * @param userIds list of user IDs to look up
+     * @return map of userId to list of IamGroupRef (id + Keycloak group name)
+     * @throws AtlanException on any API communication issue
+     */
+    public Map<String, List<IamGroupRef>> getUserGroups(List<String> userIds) throws AtlanException {
+        return getUserGroups(userIds, DEFAULT_BATCH_SIZE);
+    }
+
+    /**
+     * Bulk-fetch group memberships for the given user IDs.
+     *
+     * @param userIds list of user IDs to look up
+     * @param batchSize number of IDs per request
+     * @return map of userId to list of IamGroupRef (id + Keycloak group name)
+     * @throws AtlanException on any API communication issue
+     */
+    public Map<String, List<IamGroupRef>> getUserGroups(List<String> userIds, int batchSize) throws AtlanException {
+        if (userIds == null || userIds.isEmpty()) return new HashMap<>();
+        Map<String, List<IamGroupRef>> result = new HashMap<>();
+        String authToken = getAuthToken();
+        for (List<String> batch : partition(userIds, batchSize)) {
+            String url =
+                    getBaseUrl() + USERS_ENDPOINT + "?" + encode("filter", buildInFilter(batch)) + "&columns=groups";
+            List<IamUserResponse> responses = get(url, authToken, new TypeReference<>() {});
+            for (IamUserResponse r : responses) {
+                result.put(r.getId(), r.getGroups() != null ? r.getGroups() : Collections.emptyList());
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Bulk-fetch group aliases (display names) for the given group IDs.
+     *
+     * @param groupIds list of group IDs to look up
+     * @return map of groupId to alias (display name), empty string if no alias set
+     * @throws AtlanException on any API communication issue
+     */
+    public Map<String, String> getGroupAliases(List<String> groupIds) throws AtlanException {
+        return getGroupAliases(groupIds, DEFAULT_BATCH_SIZE);
+    }
+
+    /**
+     * Bulk-fetch group aliases (display names) for the given group IDs.
+     *
+     * @param groupIds list of group IDs to look up
+     * @param batchSize number of IDs per request
+     * @return map of groupId to alias (display name), empty string if no alias set
+     * @throws AtlanException on any API communication issue
+     */
+    public Map<String, String> getGroupAliases(List<String> groupIds, int batchSize) throws AtlanException {
+        if (groupIds == null || groupIds.isEmpty()) return new HashMap<>();
+        Map<String, String> result = new HashMap<>();
+        String authToken = getAuthToken();
+        for (List<String> batch : partition(groupIds, batchSize)) {
+            String url = getBaseUrl() + GROUPS_ENDPOINT + "?" + encode("filter", buildInFilter(batch))
+                    + "&columns=attributes";
+            List<IamGroupResponse> responses = get(url, authToken, new TypeReference<>() {});
+            for (IamGroupResponse r : responses) {
+                String alias = r.getAttributes() != null ? r.getAttributes().getAlias() : null;
+                result.put(r.getId(), alias != null ? alias : "");
+            }
+        }
+        return result;
+    }
+
+    private String buildInFilter(List<String> ids) {
+        String idList = ids.stream().map(id -> "\"" + id + "\"").collect(Collectors.joining(","));
+        return "{\"id\":{\"$in\":[" + idList + "]}}";
+    }
+
+    private String encode(String name, String value) {
+        return name + "=" + URLEncoder.encode(value, StandardCharsets.UTF_8);
+    }
+
+    private <T> T get(String url, String authToken, TypeReference<T> typeRef) throws AtlanException {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .header("Authorization", authToken)
+                    .header("Accept", "application/json")
+                    .header("x-endpoint-type", "utility")
+                    .GET()
+                    .build();
+            HttpResponse<String> response = http.send(request, HttpResponse.BodyHandlers.ofString());
+            if (response.statusCode() != 200) {
+                throw new ApiException(
+                        ErrorCode.ERROR_PASSTHROUGH, null, String.valueOf(response.statusCode()), url, response.body());
+            }
+            return testMapper != null
+                    ? testMapper.readValue(response.body(), typeRef)
+                    : client.readValue(response.body(), typeRef);
+        } catch (IOException e) {
+            throw new ApiConnectionException(ErrorCode.CONNECTION_ERROR, e, e.getMessage());
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ApiConnectionException(ErrorCode.CONNECTION_ERROR, e, e.getMessage());
+        }
+    }
+
+    private static <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> result = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            result.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return result;
+    }
+}

--- a/sdk/src/main/java/com/atlan/model/admin/IamGroupRef.java
+++ b/sdk/src/main/java/com/atlan/model/admin/IamGroupRef.java
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2024 Atlan Pte. Ltd. */
+package com.atlan.model.admin;
+
+import com.atlan.model.core.AtlanObject;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import lombok.extern.jackson.Jacksonized;
+
+/**
+ * Represents a group reference returned by the Redis-backed IAM identity API.
+ * Contains the Keycloak group ID and technical name.
+ */
+@Getter
+@Jacksonized
+@SuperBuilder(toBuilder = true)
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class IamGroupRef extends AtlanObject {
+    private static final long serialVersionUID = 2L;
+
+    /** Unique identifier of the group. */
+    String id;
+
+    /** Technical name of the group (Keycloak group name). */
+    String name;
+}


### PR DESCRIPTION
## Summary

- Move `IamClient.kt` out of the admin-export package and into the base Java SDK as `IdentityEndpoint.java` (extends `HeraclesEndpoint`)
- Add `IamGroupRef.java` model class for IAM group references
- Register `client.identity` on `AtlanClient` alongside other endpoints
- Replace 60K per-user Keycloak calls with two bulk Redis-backed IAM API calls (`/identity/users` and `/identity/groups`) — ~120 calls total regardless of user count
- Auth via `client.impersonate.escalate()` (existing SDK pattern, uses `argo-client-creds`)
- 7 unit tests in `IamClientTest.kt` using a local HTTP stub server (no external dependencies)

## Test plan

- [x] 7 unit tests pass locally (`IamClientTest`) — empty inputs, mapped groups/aliases, missing attributes, batching
- [x] CI green on `fix/csa-362-admin-export-scale`
- [x] Deployed and verified on `fs3.atlan.com` and `ai-steward.atlan.com`

## Related

- Fixes CSA-362