### PR TITLE
fix: surface unrecognized enum values during SortedSet deserialization (APP-2035)

### DIFF
--- a/sdk/src/main/java/com/atlan/serde/Serde.java
+++ b/sdk/src/main/java/com/atlan/serde/Serde.java
@@ -290,6 +290,7 @@ public class Serde {
         if (paramClass == Collection.class || paramClass == List.class) {
             return list;
         } else if (paramClass == Set.class || paramClass == SortedSet.class) {
+            list.removeIf(Objects::isNull);
             return new TreeSet<>(list);
         } else {
             throw new IOException("Unable to deserialize JSON list to Java class: " + paramClass.getCanonicalName());
@@ -358,7 +359,15 @@ public class Serde {
                 }
                 return value;
             }
-            return JacksonUtils.deserializePrimitive(element, method, innerClass);
+            Object value = JacksonUtils.deserializePrimitive(element, method, innerClass);
+            if (value == null && !element.isNull() && innerClass != null && innerClass.isEnum()) {
+                log.warn(
+                        "Unrecognized {} value '{}' in field {} — raise a ticket to get it added.",
+                        innerClass.getSimpleName(),
+                        element.asText(),
+                        fieldName);
+            }
+            return value;
         } else if (element.isArray()) {
             throw new IOException("Directly-nested arrays are not supported.");
         } else if (element.isObject()) {


### PR DESCRIPTION
## Summary

- Strip null elements from lists before constructing a `TreeSet` in `Serde.deserializeList()` — enum `fromValue()` methods (e.g. `AssetFilterGroup`) return `null` for unrecognized values, which caused a silent `NullPointerException` when inserted into a `TreeSet`, silently dropping the entire page of search results with only a WARN log
- Log a WARN at the element level in `Serde.deserializeElement()` when an enum `fromValue()` returns null for a non-null JSON value, surfacing the enum type, the unrecognized value, and the field name so it is immediately actionable

## Test plan

- [x] Verify existing unit tests pass (`./gradlew test`)
- [ ] Manually confirm that a Persona/Purpose asset with an unrecognized `denyAssetFilters` value no longer NPEs and logs the expected WARN

Fixes: [APP-2035](https://linear.app/atlan-epd/issue/APP-2035)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[APP-2035]: https://atlanhq.atlassian.net/browse/APP-2035?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ