### PR TITLE
ci: forward CLIENT_ID and CLIENT_SECRET to package test jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,6 +145,8 @@ jobs:
         env:
           ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
           ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/home/runner"
         run: |
@@ -190,6 +192,8 @@ jobs:
         env:
           ATLAN_BASE_URL: ${{ secrets.ATLAN_BASE_URL }}
           ATLAN_API_KEY: ${{ secrets.ATLAN_API_KEY }}
+          CLIENT_ID: ${{ secrets.CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.CLIENT_SECRET }}
           NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
           JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/home/runner"
         run: ./gradlew -PpackageTests :samples:packages:${{ matrix.tests }}:test -x assemble -x testClasses -x buildSrc:jar


### PR DESCRIPTION
## Summary

- `ImpersonationEndpoint` reads `CLIENT_ID` and `CLIENT_SECRET` directly from `System.getenv()`, but neither secret was forwarded to the `package-test` or `asset-import-test` job env blocks in `test.yml`
- This caused `ExportAllAdminInfoTest` and `ExportUsersTest` in the `admin-export` package to fail with `ATLAN-JAVA-400-040 Missing privileged credentials to impersonate users` — even though the secrets exist in GitHub

## Test plan

- [ ] Re-run the failing CI job (`Packages (admin-export)`) and confirm `ExportAllAdminInfoTest` / `ExportUsersTest` no longer throw `MISSING_CREDENTIALS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)