### PR TITLE
fix(serde): handle raw % in README CSS without crashing export

### DIFF
--- a/sdk/src/main/java/com/atlan/util/StringUtils.java
+++ b/sdk/src/main/java/com/atlan/util/StringUtils.java
@@ -93,7 +93,14 @@ public final class StringUtils {
      * @return decoded README content (HTML)
      */
     public static String decodeContent(String encoded) {
-        return encoded == null ? null : URLDecoder.decode(encoded.replace("%20", "+"), StandardCharsets.UTF_8);
+        if (encoded == null) return null;
+        try {
+            return URLDecoder.decode(encoded.replace("%20", "+"), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException e) {
+            // README content may contain raw % in CSS (e.g. width:100%;) that was never
+            // URL-encoded — return as-is rather than crashing the entire export
+            return encoded;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- `StringUtils.decodeContent` calls `URLDecoder.decode()` on README descriptions during deserialization. When a README contains raw `%` in inline CSS (e.g. `width:100%;`), the decoder throws `IllegalArgumentException` — aborting the entire export with no partial output.
- Added a `catch (IllegalArgumentException e)` fallback to return the raw string as-is. Content that was never URL-encoded is already correct; valid `%XX` sequences are unaffected.
- Confirmed fix location via full call chain trace: `AssetDeserializer.java:336` → `StringUtils.java:96` → `URLDecoder.decode()` → `IllegalArgumentException` → caught at `LiveAtlanResponseGetter.java:170` → `raiseMalformedJsonError:266` → export exits with code 1.

## Root Cause

`AssetDeserializer.java:336` calls `decodeContent()` specifically for `Readme` type assets:
```java
if (typeName != null && typeName.equals("Readme")) {
    builder.description(StringUtils.decodeContent(builder.build().getDescription()));
}
```

`StringUtils.decodeContent` (`StringUtils.java:96`) had no guard against `IllegalArgumentException`:
```java
// Before
public static String decodeContent(String encoded) {
    return encoded == null ? null : URLDecoder.decode(encoded.replace("%20", "+"), StandardCharsets.UTF_8);
}
```

## Fix

```java
// After
public static String decodeContent(String encoded) {
    if (encoded == null) return null;
    try {
        return URLDecoder.decode(encoded.replace("%20", "+"), StandardCharsets.UTF_8);
    } catch (IllegalArgumentException e) {
        // README content may contain raw % in CSS (e.g. width:100%;) that was never
        // URL-encoded — return as-is rather than crashing the entire export
        return encoded;
    }
}
```

## Test Plan

- [ ] Existing unit tests pass (`./gradlew test`)
- [ ] Verify `decodeContent("width:100%; border-collapse:collapse; ")` returns the raw string without throwing
- [ ] Verify `decodeContent("hello+world%21")` still returns `hello world!` (valid URL-encoded content unaffected)
- [ ] Verify `decodeContent(null)` returns `null`
- [ ] Run export workflow after deploying — confirm it completes without exit code 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)