### PR TITLE
fix(adls): swap Azure HTTP transport from Netty to OkHttp (CSA-390)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ angus-mail = "2.0.5"
 pkl = "0.31.1"
 adls = "12.26.3"
 azure = "1.18.2"
+azure-core-http-okhttp = "1.13.4"
 guava = "33.6.0-jre"
 openlineage = "1.46.0"
 kotlin = "2.3.20"
@@ -57,6 +58,7 @@ gcs = { module = "com.google.cloud:google-cloud-storage" }
 gcs-control = { module = "com.google.cloud:google-cloud-storage-control" }
 adls = { module = "com.azure:azure-storage-file-datalake", version.ref = "adls" }
 azure-identity = { module = "com.azure:azure-identity", version.ref = "azure" }
+azure-core-http-okhttp = { module = "com.azure:azure-core-http-okhttp", version.ref = "azure-core-http-okhttp" }
 system-stubs = { module = "uk.org.webcompere:system-stubs-testng", version.ref = "system-stubs" }
 fastcsv = { module = "de.siegmar:fastcsv", version.ref = "fastcsv" }
 apache-poi = { module = "org.apache.poi:poi", version.ref = "poi" }

--- a/package-toolkit/runtime/build.gradle.kts
+++ b/package-toolkit/runtime/build.gradle.kts
@@ -25,8 +25,13 @@ dependencies {
     api(libs.awssdk.sts)
     api(platform(libs.gcs.bom))
     api(libs.gcs)
-    api(libs.azure.identity)
-    api(libs.adls)
+    api(libs.azure.identity) {
+        exclude(group = "com.azure", module = "azure-core-http-netty")
+    }
+    api(libs.adls) {
+        exclude(group = "com.azure", module = "azure-core-http-netty")
+    }
+    api(libs.azure.core.http.okhttp)
     implementation(libs.sqlite)
     implementation(libs.simple.java.mail)
     implementation(libs.log4j.core) // This gives us the OOTB-log4j appenders (that we MUST have for pattern-handling)
@@ -189,7 +194,7 @@ tasks {
             include(dependency("com.microsoft.azure:msal4j-persistence-extension:.*"))
             include(dependency("net.java.dev.jna:jna:.*"))
             include(dependency("net.java.dev.jna:jna-platform:.*"))
-            include(dependency("com.azure:azure-core-http-netty:.*"))
+            include(dependency("com.azure:azure-core-http-okhttp:.*"))
             include(dependency("com.azure:azure-core:.*"))
             include(dependency("com.azure:azure-json:.*"))
             include(dependency("com.azure:azure-storage-blob:.*"))

--- a/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/objectstore/ADLSSync.kt
+++ b/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/objectstore/ADLSSync.kt
@@ -2,6 +2,7 @@
    Copyright 2023 Atlan Pte. Ltd. */
 package com.atlan.pkg.objectstore
 
+import com.azure.core.http.okhttp.OkHttpAsyncHttpClientBuilder
 import com.azure.identity.ClientSecretCredentialBuilder
 import com.azure.storage.blob.BlobContainerClient
 import com.azure.storage.blob.BlobContainerClientBuilder
@@ -36,6 +37,7 @@ class ADLSSync(
     private val blobContainerClient: BlobContainerClient?
 
     init {
+        val httpClient = OkHttpAsyncHttpClientBuilder().build()
         if (tenantId.isNotBlank() && clientId.isNotBlank()) {
             logger.info { "Authenticating to ADLS using provided tenant and client IDs and secrets." }
             val credential =
@@ -43,11 +45,13 @@ class ADLSSync(
                     .tenantId(tenantId)
                     .clientId(clientId)
                     .clientSecret(clientSecret)
+                    .httpClient(httpClient)
                     .build()
             adlsClient =
                 DataLakeServiceClientBuilder()
                     .endpoint("https://$accountName.dfs.core.windows.net")
                     .credential(credential)
+                    .httpClient(httpClient)
                     .buildClient()
             blobContainerClient = null
         } else {
@@ -61,6 +65,7 @@ class ADLSSync(
                     .endpoint("https://$accountName.blob.core.windows.net")
                     .credential(credential)
                     .containerName(containerName)
+                    .httpClient(httpClient)
                     .buildClient()
             adlsClient = null
         }


### PR DESCRIPTION
## Summary

- **Root cause:** `azure-core-http-netty 1.18.2` (compiled against Netty 4.1.x) conflicts with `io.netty 4.2.12.Final` (bumped Apr 16). Netty 4.2 removed `DefaultHeaders.containsAny(Object, Object, BiPredicate)`, causing `NoSuchMethodError` the moment MSAL4J attempts Azure AD token acquisition via the Netty HTTP pipeline.
- **Fix:** Replace `azure-core-http-netty` with `azure-core-http-okhttp` (OkHttp has no Netty dependency). OkHttp is already shaded into the fat-jar via the OTel sender, so this adds no new weight to the artifact.
- **Belt-and-suspenders:** Explicit `OkHttpAsyncHttpClientBuilder` wired into all three ADLS client builders (`ClientSecretCredentialBuilder`, `DataLakeServiceClientBuilder`, `BlobContainerClientBuilder`) so transport selection is deterministic regardless of classpath order (AWS SDK's `netty-nio-client` is still present).

**Affected tenants (confirmed):** Zoetis (`zoetis-dev.atlan.com`, ZEN-122712), P&G (`pg-dev.atlan.com`), Nyrstar (`nyrstar.atlan.com`). Any CSA package using ADLS auth is impacted — this fixes CSA-390 and CSA-400.

## Changes

- `gradle/libs.versions.toml` — add `azure-core-http-okhttp = "1.13.4"` version + library entry
- `package-toolkit/runtime/build.gradle.kts` — exclude `azure-core-http-netty` from `azure.identity` + `adls` transitives; add `azure-core-http-okhttp` dep; swap shadowJar include
- `package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/objectstore/ADLSSync.kt` — wire explicit OkHttp `HttpClient` into all Azure client builders

## Test plan

- [x] `./gradlew :package-toolkit:runtime:dependencies` — `azure-core-http-okhttp:1.13.4` present, `azure-core-http-netty` absent
- [x] `./gradlew :package-toolkit:runtime:shadowJar` — builds clean; jar contains `com/azure/core/http/okhttp/*`, zero `com/azure/core/http/netty/*` classes
- [x] `./gradlew :package-toolkit:runtime:test` — all unit tests pass
- [ ] End-to-end: rerun `@csa/asset-import` against `zoetis-dev.atlan.com` with ADLS Service Principal auth — should reach file ingestion without `NoSuchMethodError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)