### PR TITLE
fix(csa-403): guard ENUM/SET types in ColumnXformer to prevent NumberFormatException

### DIFF
--- a/package-toolkit/runtime/src/test/kotlin/serde/DataTypeXformerTest.kt
+++ b/package-toolkit/runtime/src/test/kotlin/serde/DataTypeXformerTest.kt
@@ -8,6 +8,10 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class DataTypeXformerTest {
+    private val dataTypeField = DataTypeXformer.FIELDS.first()
+
+    // --- getPrecision / getScale / getMaxLength ---
+
     @Test
     fun `DECIMAL precision and scale parsed correctly`() {
         assertEquals(10, DataTypeXformer.getPrecision("DECIMAL(10,2)"))
@@ -36,5 +40,55 @@ class DataTypeXformerTest {
         assertNull(DataTypeXformer.getPrecision(null))
         assertNull(DataTypeXformer.getScale(null))
         assertNull(DataTypeXformer.getMaxLength(null))
+    }
+
+    // --- decode: type extraction ---
+
+    @Test
+    fun `VARCHAR(MAX) - type decoded as VARCHAR even when max length is null`() {
+        assertNull(DataTypeXformer.getMaxLength("VARCHAR(MAX)"))
+        assertEquals("VARCHAR", DataTypeXformer.decode("VARCHAR(MAX)", dataTypeField))
+    }
+
+    @Test
+    fun `INT - type decoded as INT even when all numeric params are null`() {
+        assertNull(DataTypeXformer.getPrecision("INT"))
+        assertNull(DataTypeXformer.getScale("INT"))
+        assertNull(DataTypeXformer.getMaxLength("INT"))
+        assertEquals("INT", DataTypeXformer.decode("INT", dataTypeField))
+    }
+
+    @Test
+    fun `DECIMAL - type decoded as DECIMAL regardless of precision and scale`() {
+        assertEquals("DECIMAL", DataTypeXformer.decode("DECIMAL(10,2)", dataTypeField))
+    }
+
+    @Test
+    fun `VARCHAR with numeric length - type decoded as VARCHAR`() {
+        assertEquals("VARCHAR", DataTypeXformer.decode("VARCHAR(255)", dataTypeField))
+    }
+
+    @Test
+    fun `NVARCHAR mapped to VARCHAR on decode`() {
+        assertEquals("VARCHAR", DataTypeXformer.decode("NVARCHAR(100)", dataTypeField))
+    }
+
+    @Test
+    fun `lowercase type name is uppercased on decode`() {
+        assertEquals("VARCHAR", DataTypeXformer.decode("varchar(255)", dataTypeField))
+        assertEquals("INT", DataTypeXformer.decode("int", dataTypeField))
+    }
+
+    @Test
+    fun `spurious type values decoded as null`() {
+        assertNull(DataTypeXformer.decode("DATA TYPE", dataTypeField))
+        assertNull(DataTypeXformer.decode("NULL", dataTypeField))
+    }
+
+    @Test
+    fun `null or blank type decoded as null`() {
+        assertNull(DataTypeXformer.decode(null, dataTypeField))
+        assertNull(DataTypeXformer.decode("", dataTypeField))
+        assertNull(DataTypeXformer.decode("   ", dataTypeField))
     }
 }

--- a/package-toolkit/runtime/src/test/kotlin/serde/DataTypeXformerTest.kt
+++ b/package-toolkit/runtime/src/test/kotlin/serde/DataTypeXformerTest.kt
@@ -1,0 +1,40 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2023 Atlan Pte. Ltd. */
+package serde
+
+import com.atlan.pkg.serde.cell.DataTypeXformer
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class DataTypeXformerTest {
+    @Test
+    fun `DECIMAL precision and scale parsed correctly`() {
+        assertEquals(10, DataTypeXformer.getPrecision("DECIMAL(10,2)"))
+        assertEquals(2.0, DataTypeXformer.getScale("DECIMAL(10,2)"))
+    }
+
+    @Test
+    fun `VARCHAR max length parsed correctly`() {
+        assertEquals(255L, DataTypeXformer.getMaxLength("VARCHAR(255)"))
+    }
+
+    @Test
+    fun `VARCHAR MAX returns null`() {
+        assertNull(DataTypeXformer.getMaxLength("VARCHAR(MAX)"))
+    }
+
+    @Test
+    fun `plain type - all return null`() {
+        assertNull(DataTypeXformer.getPrecision("INT"))
+        assertNull(DataTypeXformer.getScale("INT"))
+        assertNull(DataTypeXformer.getMaxLength("INT"))
+    }
+
+    @Test
+    fun `null input - all return null`() {
+        assertNull(DataTypeXformer.getPrecision(null))
+        assertNull(DataTypeXformer.getScale(null))
+        assertNull(DataTypeXformer.getMaxLength(null))
+    }
+}

--- a/samples/packages/relational-assets-builder/src/main/kotlin/com/atlan/pkg/rab/ColumnXformer.kt
+++ b/samples/packages/relational-assets-builder/src/main/kotlin/com/atlan/pkg/rab/ColumnXformer.kt
@@ -77,8 +77,13 @@ class ColumnXformer(
         var scale: Double? = null
         var maxLength: Long? = null
         if (rawDataType.isNotBlank()) {
-            if (!rawDataType.contains("<") && !rawDataType.contains(">")) {
-                // Only attempt to parse things like precision, scale and max-length if this is not a complex type
+            val baseType = displayDataType.substringBefore("(").trim().uppercase()
+            if (!rawDataType.contains("<") && !rawDataType.contains(">") &&
+                baseType !in setOf("ENUM", "SET")
+            ) {
+                // Only attempt to parse precision, scale and max-length for numeric/sized types.
+                // Excludes complex types (angle-bracket params) and MySQL string-enum types
+                // (ENUM/SET) whose parenthetical content contains string values, not numbers.
                 precision = DataTypeXformer.getPrecision(rawDataType)
                 scale = DataTypeXformer.getScale(rawDataType)
                 maxLength = DataTypeXformer.getMaxLength(rawDataType)

--- a/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/EnumDataTypeRABTest.kt
+++ b/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/EnumDataTypeRABTest.kt
@@ -1,0 +1,169 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2023 Atlan Pte. Ltd. */
+package com.atlan.pkg.rab
+
+import AssetImportCfg
+import RelationalAssetsBuilderCfg
+import com.atlan.model.assets.Column
+import com.atlan.model.assets.Connection
+import com.atlan.model.assets.Table
+import com.atlan.model.enums.AtlanConnectorType
+import com.atlan.model.fields.AtlanField
+import com.atlan.pkg.PackageTest
+import com.atlan.pkg.Utils
+import com.atlan.pkg.rab.Importer.PREVIOUS_FILES_PREFIX
+import java.io.File
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+/**
+ * Test that RAB handles Glue enum data types (e.g. enum('a','b')) without crashing.
+ * Regression test for CSA-403: NumberFormatException when enum values were mistaken for
+ * precision/scale parameters by DataTypeXformer.
+ */
+class EnumDataTypeRABTest : PackageTest("enum") {
+    override val logger = Utils.getLogger(this.javaClass.name)
+
+    private val conn1 = makeUnique("c1")
+    private val conn1Type = AtlanConnectorType.ICEBERG
+
+    private val testFile = "input.csv"
+    private val files = listOf(testFile, "debug.log")
+
+    private fun prepFile() {
+        val input = Paths.get("src", "test", "resources", "assets-enum.csv").toFile()
+        val output = Paths.get(testDirectory, testFile).toFile()
+        input.useLines { lines ->
+            lines.forEach { line ->
+                val revised =
+                    line
+                        .replace("{{CONNECTION1}}", conn1)
+                        .replace("{{API_TOKEN_USER}}", client.users.currentUser.username)
+                output.appendText("$revised\n")
+            }
+        }
+    }
+
+    private val connectionAttrs: List<AtlanField> =
+        listOf(
+            Connection.NAME,
+            Connection.CONNECTOR_TYPE,
+        )
+
+    private val columnAttrs: List<AtlanField> =
+        listOf(
+            Column.NAME,
+            Column.DATA_TYPE,
+            Column.RAW_DATA_TYPE_DEFINITION,
+            Column.ORDER,
+            Column.PRECISION,
+            Column.NUMERIC_SCALE,
+            Column.MAX_LENGTH,
+        )
+
+    override fun setup() {
+        prepFile()
+        runCustomPackage(
+            RelationalAssetsBuilderCfg(
+                assetsFile = Paths.get(testDirectory, testFile).toString(),
+                assetsUpsertSemantic = "upsert",
+                assetsFailOnErrors = true,
+                deltaSemantic = "full",
+            ),
+            Importer::main,
+        )
+        runCustomPackage(
+            AssetImportCfg(
+                assetsFile = "$testDirectory${File.separator}current-file-transformed.csv",
+                assetsUpsertSemantic = "upsert",
+                assetsDeltaSemantic = "full",
+                assetsFailOnErrors = true,
+                assetsPreviousFilePrefix = PREVIOUS_FILES_PREFIX,
+            ),
+            com.atlan.pkg.aim.Importer::main,
+        )
+    }
+
+    override fun teardown() {
+        removeConnection(conn1, conn1Type)
+    }
+
+    @Test(groups = ["rab.enum.create"])
+    fun enumColumnUpsertedWithoutCrash() {
+        // Core regression: importing enum('scheduled',...) must not throw NumberFormatException
+        val c1 = Connection.findByName(client, conn1, conn1Type, connectionAttrs)[0]!!
+        val request =
+            Column
+                .select(client)
+                .where(Column.CONNECTION_QUALIFIED_NAME.eq(c1.qualifiedName))
+                .where(Column.NAME.eq("status"))
+                .includesOnResults(columnAttrs)
+                .toRequest()
+        val response = retrySearchUntil(request, 1)
+        val col = response.assets[0] as Column
+        assertEquals("status", col.name)
+        // dataType is the full string — baseTypeName only strips <> angle-bracket params, not ()
+        assertEquals("enum('scheduled','failed','cancelled','retry','success','deliveryInProgress')", col.dataType)
+        // rawDataTypeDefinition preserves the full original string
+        assertEquals("enum('scheduled','failed','cancelled','retry','success','deliveryInProgress')", col.rawDataTypeDefinition)
+        // precision and scale must be null — enum values are not numeric
+        assertNull(col.precision)
+        assertNull(col.numericScale)
+        assertNull(col.maxLength)
+    }
+
+    @Test(groups = ["rab.enum.create"])
+    fun enumColumnsHaveCorrectOrder() {
+        val c1 = Connection.findByName(client, conn1, conn1Type, connectionAttrs)[0]!!
+        val request =
+            Table
+                .select(client)
+                .where(Table.CONNECTION_QUALIFIED_NAME.eq(c1.qualifiedName))
+                .where(Table.NAME.eq("webhook_event"))
+                .toRequest()
+        val tableResponse = retrySearchUntil(request, 1)
+        val tbl = tableResponse.assets[0] as Table
+        assertNotNull(tbl)
+
+        // All 3 columns (status, created_at, retry_count) must have been created
+        val colRequest =
+            Column
+                .select(client)
+                .where(Column.TABLE_QUALIFIED_NAME.eq(tbl.qualifiedName))
+                .includesOnResults(columnAttrs)
+                .toRequest()
+        val colResponse = retrySearchUntil(colRequest, 3)
+        assertEquals(3, colResponse.assets.size)
+        val names = colResponse.assets.map { it.name }.toSet()
+        assertEquals(setOf("status", "created_at", "retry_count"), names)
+    }
+
+    @Test(groups = ["rab.enum.create"])
+    fun nonEnumColumnsUnaffected() {
+        // retry_count is plain int — make sure it still upserts correctly alongside enum columns
+        val c1 = Connection.findByName(client, conn1, conn1Type, connectionAttrs)[0]!!
+        val request =
+            Column
+                .select(client)
+                .where(Column.CONNECTION_QUALIFIED_NAME.eq(c1.qualifiedName))
+                .where(Column.NAME.eq("retry_count"))
+                .includesOnResults(columnAttrs)
+                .toRequest()
+        val response = retrySearchUntil(request, 1)
+        val col = response.assets[0] as Column
+        assertEquals("int", col.dataType)
+    }
+
+    @Test(dependsOnGroups = ["rab.enum.create"])
+    fun filesCreated() {
+        validateFilesExist(files)
+    }
+
+    @Test(dependsOnGroups = ["rab.enum.create"])
+    fun errorFreeLog() {
+        validateErrorFreeLog()
+    }
+}

--- a/samples/packages/relational-assets-builder/src/test/resources/assets-enum.csv
+++ b/samples/packages/relational-assets-builder/src/test/resources/assets-enum.csv
@@ -1,0 +1,12 @@
+typeName,connectionName,connectorType,databaseName,schemaName,entityName,columnName,dataType,displayName,description,adminRoles,adminGroups,adminUsers
+Connection,{{CONNECTION1}},iceberg,,,,,,,,$admin,,{{API_TOKEN_USER}}
+Database,{{CONNECTION1}},iceberg,ENUM_DB,,,,,,,,,
+Schema,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,,,,,,,,
+Table,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,WEBHOOK_EVENT,,,,,,,
+Column,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,WEBHOOK_EVENT,STATUS,"enum('scheduled','failed','cancelled','retry','success','deliveryInProgress')",,,,,
+Column,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,WEBHOOK_EVENT,CREATED_AT,timestamp,,,,,
+Column,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,WEBHOOK_EVENT,RETRY_COUNT,int,,,,,
+Table,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,WEBHOOK_SESSION,,,,,,,
+Column,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,WEBHOOK_SESSION,CALLBACK_METHOD,"enum('PUT','POST')",,,,,
+Column,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,WEBHOOK_SESSION,PAYLOAD_TYPE,"enum('application/json','application/xml','text/plain')",,,,,
+Column,{{CONNECTION1}},iceberg,ENUM_DB,ENUM_SCHEMA,WEBHOOK_SESSION,TIMEOUT_MS,bigint,,,,,


### PR DESCRIPTION
## Summary

- **Root cause:** AWS Glue uses `enum('scheduled','pending','cancelled')` with parentheses `()`, not angle brackets `<>`. The existing guard in `ColumnXformer.mapAsset()` only excluded `<>`-style complex types, so enum values passed through to `DataTypeXformer.getPrecision()` which called `.toInt()` on string literals like `'scheduled'` → `NumberFormatException`.
- **Fix:** Extract the base type via `substringBefore("(")` before checking set membership, and exclude `ENUM` and `SET` from the precision/scale/maxLength parse block. MySQL `SET('a','b')` has the same parenthetical-string pattern and is covered by the same guard.
- **Scope:** `DataTypeXformer` and `CellXformer` are intentionally left unchanged — fixing the guard upstream in `ColumnXformer` is safer than silently swallowing parse errors in shared utilities (which would also suppress legitimate errors in truly numeric fields).

## Changes

| File | Change |
|------|--------|
| `ColumnXformer.kt` | Extended type guard: `substringBefore("(")` + `ENUM`/`SET` exclusion |
| `EnumDataTypeRABTest.kt` | New package test: verifies no crash + `precision`/`scale`/`maxLength` null for enum columns |
| `assets-enum.csv` | Test fixture with real Glue enum columns (`enum('scheduled',...)`, `enum('PUT','POST')`, etc.) |
| `DataTypeXformerTest.kt` | Unit tests for `getPrecision`/`getScale`/`getMaxLength` on numeric/sized types |

## Test plan

- [ ] RAB transform stage: `NumberFormatException` is eliminated for `enum(...)` columns
- [ ] `EnumDataTypeRABTest` — 5 tests covering crash-free upsert, column order, non-enum column unaffected, files created, error-free log
- [ ] `DataTypeXformerTest` — unit tests for `DECIMAL(10,2)`, `VARCHAR(255)`, `VARCHAR(MAX)`, plain `INT`, nulls
- [ ] Existing RAB package tests (`ComplexDataTypeRABTest`, etc.) remain green

Fixes: [CSA-403](https://linear.app/atlan-epd/issue/CSA-403)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[CSA-403]: https://atlanhq.atlassian.net/browse/CSA-403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ