### PR TITLE
test: add ES consistency condition to flaky awsTags/links retries

### DIFF
--- a/package-toolkit/testing/src/main/kotlin/com/atlan/pkg/PackageTest.kt
+++ b/package-toolkit/testing/src/main/kotlin/com/atlan/pkg/PackageTest.kt
@@ -229,12 +229,16 @@ abstract class PackageTest(
      *
      * @param request search request to run
      * @param expectedSize expected number of results from the search
-     * @return the response, either with the expected number of results or after exceeding the retry limit
+     * @param isDeleteQuery if true, also retries while any returned assets are still in ACTIVE status
+     * @param condition optional extra predicate on the response — retries continue until this also returns true,
+     *        useful when related attributes (struct collections, relationship counts) lag behind the primary asset
+     * @return the response, either satisfying all conditions or after exceeding the retry limit
      */
     fun retrySearchUntil(
         request: IndexSearchRequest,
         expectedSize: Long,
         isDeleteQuery: Boolean = false,
+        condition: ((IndexSearchResponse) -> Boolean)? = null,
     ): IndexSearchResponse {
         var count = 1
         var response = request.search(client)
@@ -245,7 +249,7 @@ abstract class PackageTest(
                 ?.toList()
                 ?.isNotEmpty() ?: false
         }
-        while ((response.approximateCount < expectedSize || remainingActive) && count < (client.maxNetworkRetries * 2)) {
+        while ((response.approximateCount < expectedSize || remainingActive || (condition != null && !condition(response))) && count < (client.maxNetworkRetries * 2)) {
             Thread.sleep(HttpClient.waitTime(count).toMillis())
             response = request.search(client)
             if (isDeleteQuery) {

--- a/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/AvoidDuplicateLinkTest.kt
+++ b/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/AvoidDuplicateLinkTest.kt
@@ -254,7 +254,7 @@ class AvoidDuplicateLinkTest : PackageTest("adl") {
                 .includeOnRelations(Link.LINK)
                 .includeOnRelations(Link.STATUS)
                 .toRequest()
-        val response = retrySearchUntil(request, 1)
+        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? Database)?.links?.size == 2 })
         val found = response.assets
         assertEquals(1, found.size)
         val db = found[0] as Database
@@ -282,7 +282,7 @@ class AvoidDuplicateLinkTest : PackageTest("adl") {
                 .includeOnRelations(Link.LINK)
                 .includeOnRelations(Link.STATUS)
                 .toRequest()
-        val response = retrySearchUntil(request, 1)
+        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? Database)?.links?.size == 3 })
         val found = response.assets
         assertEquals(1, found.size)
         val db = found[0] as Database

--- a/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/S3WithPrefixesTest.kt
+++ b/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/S3WithPrefixesTest.kt
@@ -162,7 +162,7 @@ class S3WithPrefixesTest : PackageTest("swp") {
                 .includesOnResults(bucketAttrs)
                 .includeOnRelations(Asset.NAME)
                 .toRequest()
-        val response = retrySearchUntil(request, 1)
+        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? S3Bucket)?.awsTags?.size == 2 })
         val found = response.assets
         assertEquals(1, found.size)
         val b = found[0] as S3Bucket
@@ -190,7 +190,7 @@ class S3WithPrefixesTest : PackageTest("swp") {
                 .includesOnResults(bucketAttrs)
                 .includeOnRelations(Asset.NAME)
                 .toRequest()
-        val response = retrySearchUntil(request, 1)
+        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? S3Bucket)?.awsTags?.size == 2 })
         val found = response.assets
         assertEquals(1, found.size)
         val b = found[0] as S3Bucket
@@ -273,7 +273,7 @@ class S3WithPrefixesTest : PackageTest("swp") {
                 .includesOnResults(prefixAttrs)
                 .includeOnRelations(Asset.NAME)
                 .toRequest()
-        val response = retrySearchUntil(request, 1)
+        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? S3Prefix)?.awsTags?.size == 2 })
         val found = response.assets
         assertEquals(1, found.size)
         val p = found[0] as S3Prefix
@@ -488,7 +488,7 @@ class S3WithPrefixesTest : PackageTest("swp") {
                 .includesOnResults(objectAttrs)
                 .includeOnRelations(Asset.NAME)
                 .toRequest()
-        val response = retrySearchUntil(request, 1)
+        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? S3Object)?.awsTags?.size == 1 })
         val found = response.assets
         assertEquals(1, found.size)
         val o = found[0] as S3Object


### PR DESCRIPTION
## Summary

- `S3WithPrefixesTest` and `AvoidDuplicateLinkTest` were intermittently failing because `retrySearchUntil` only waited for the primary asset count to appear in Elasticsearch — it did not wait for nested attributes (`awsTags` struct collection, `links` relationship count) to be indexed, which lag behind the primary asset.
- Extended `retrySearchUntil` in `PackageTest` with an optional `condition: ((IndexSearchResponse) -> Boolean)?` lambda parameter; the retry loop now also waits until the condition returns `true`.
- Applied the condition at 4 `awsTags` sites in `S3WithPrefixesTest` and 2 `links` sites in `AvoidDuplicateLinkTest`.

## Test plan

- [ ] `S3WithPrefixesTest` — `bucket1Created`, `bucket2Created`, `prefix3Created`, `object4Created` now wait for `awsTags` to be non-empty before asserting size
- [ ] `AvoidDuplicateLinkTest` — `validateTwoLinks` and `validateThreeLinks` now wait for the expected number of links before asserting
- [ ] All other `retrySearchUntil` call sites are unaffected (condition defaults to `null`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)