### PR TITLE
test: fetch full asset via .get() for awsTags/links assertions

### DIFF
--- a/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/AvoidDuplicateLinkTest.kt
+++ b/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/AvoidDuplicateLinkTest.kt
@@ -254,10 +254,10 @@ class AvoidDuplicateLinkTest : PackageTest("adl") {
                 .includeOnRelations(Link.LINK)
                 .includeOnRelations(Link.STATUS)
                 .toRequest()
-        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? Database)?.links?.size == 2 })
+        val response = retrySearchUntil(request, 1)
         val found = response.assets
         assertEquals(1, found.size)
-        val db = found[0] as Database
+        val db = Database.get(client, found[0].guid, true)
         assertEquals(DB_NAME, db.name)
         assertEquals(c1.qualifiedName, db.connectionQualifiedName)
         assertEquals(conn1Type, db.connectorType)
@@ -282,10 +282,10 @@ class AvoidDuplicateLinkTest : PackageTest("adl") {
                 .includeOnRelations(Link.LINK)
                 .includeOnRelations(Link.STATUS)
                 .toRequest()
-        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? Database)?.links?.size == 3 })
+        val response = retrySearchUntil(request, 1)
         val found = response.assets
         assertEquals(1, found.size)
-        val db = found[0] as Database
+        val db = Database.get(client, found[0].guid, true)
         assertEquals(DB_NAME, db.name)
         assertEquals(c1.qualifiedName, db.connectionQualifiedName)
         assertEquals(conn1Type, db.connectorType)

--- a/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/S3WithPrefixesTest.kt
+++ b/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/S3WithPrefixesTest.kt
@@ -162,10 +162,10 @@ class S3WithPrefixesTest : PackageTest("swp") {
                 .includesOnResults(bucketAttrs)
                 .includeOnRelations(Asset.NAME)
                 .toRequest()
-        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? S3Bucket)?.awsTags?.size == 2 })
+        val response = retrySearchUntil(request, 1)
         val found = response.assets
         assertEquals(1, found.size)
-        val b = found[0] as S3Bucket
+        val b = S3Bucket.get(client, found[0].guid, true)
         assertEquals("bucket-1", b.name)
         assertEquals(c1.qualifiedName, b.connectionQualifiedName)
         assertEquals(conn1Type, b.connectorType)
@@ -190,10 +190,10 @@ class S3WithPrefixesTest : PackageTest("swp") {
                 .includesOnResults(bucketAttrs)
                 .includeOnRelations(Asset.NAME)
                 .toRequest()
-        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? S3Bucket)?.awsTags?.size == 2 })
+        val response = retrySearchUntil(request, 1)
         val found = response.assets
         assertEquals(1, found.size)
-        val b = found[0] as S3Bucket
+        val b = S3Bucket.get(client, found[0].guid, true)
         assertEquals("bucket-2", b.name)
         assertEquals(c1.qualifiedName, b.connectionQualifiedName)
         assertEquals(conn1Type, b.connectorType)
@@ -273,10 +273,10 @@ class S3WithPrefixesTest : PackageTest("swp") {
                 .includesOnResults(prefixAttrs)
                 .includeOnRelations(Asset.NAME)
                 .toRequest()
-        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? S3Prefix)?.awsTags?.size == 2 })
+        val response = retrySearchUntil(request, 1)
         val found = response.assets
         assertEquals(1, found.size)
-        val p = found[0] as S3Prefix
+        val p = S3Prefix.get(client, found[0].guid, true)
         assertEquals("prefix-3", p.name)
         assertEquals(c1.qualifiedName, p.connectionQualifiedName)
         assertEquals(conn1Type, p.connectorType)
@@ -488,10 +488,10 @@ class S3WithPrefixesTest : PackageTest("swp") {
                 .includesOnResults(objectAttrs)
                 .includeOnRelations(Asset.NAME)
                 .toRequest()
-        val response = retrySearchUntil(request, 1, condition = { r -> (r.assets?.firstOrNull() as? S3Object)?.awsTags?.size == 1 })
+        val response = retrySearchUntil(request, 1)
         val found = response.assets
         assertEquals(1, found.size)
-        val o = found[0] as S3Object
+        val o = S3Object.get(client, found[0].guid, true)
         assertEquals("object-4", o.name)
         assertEquals(c1.qualifiedName, o.connectionQualifiedName)
         assertEquals(conn1Type, o.connectorType)


### PR DESCRIPTION
## Summary

- `S3WithPrefixesTest` (`bucket1Created`, `bucket2Created`, `prefix3Created`, `object4Created`) and `AvoidDuplicateLinkTest` (`validateTwoLinks`, `validateThreeLinks`) were failing because the ES search index was not returning struct fields (`awsTags`) or relationship counts (`links`) reliably — the data simply wasn't present in the index, so no amount of retrying would satisfy the condition.
- Replaced the condition-based `retrySearchUntil` with a plain existence check (count ≥ 1), then fetched the full asset via `Asset.get(client, guid, true)` before asserting on `awsTags`/`links`. This bypasses the search index entirely for these fields and reads them directly from the API.
- The previous fix in #2487 added retry conditions that correctly kept looping, but the data was never in the index to begin with, so the loop always timed out.

## Test plan

- [ ] `S3WithPrefixesTest` — `bucket1Created`, `bucket2Created`, `prefix3Created`, `object4Created` now assert `awsTags` from a direct `.get()` response
- [ ] `AvoidDuplicateLinkTest` — `validateTwoLinks` and `validateThreeLinks` now assert `links` from a direct `.get()` response
- [ ] All other test methods in both files are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)