### PR TITLE
ci: add daily leangraph-test integration test workflow

### DIFF
--- a/.github/workflows/test-leangraph.yml
+++ b/.github/workflows/test-leangraph.yml
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: Apache-2.0
+# Copyright 2022 Atlan Pte. Ltd.
+name: "Test (leangraph-test)"
+permissions:
+  contents: read
+
+on:
+  schedule:
+    # 09:00 IST (UTC+5:30) = 03:30 UTC, weekdays only
+    - cron: "30 3 * * 1-5"
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: "Build"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          add-job-summary: on-failure
+      - name: Compile
+        run: ./gradlew assemble shadowJar testClasses
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: build-artifacts
+          path: |
+            **/build/libs/*.jar
+            **/build/classes/
+          retention-days: 1
+          compression-level: 0
+  list-integration-tests:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.test-files.outputs.tests }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: List integration tests
+        id: test-files
+        run: |
+          tests=$(ls integration-tests/src/test/java/com/atlan/java/sdk/*Test.java | sed -E 's|.*/src/test/java/com/atlan/java/sdk/||; s|/|.|g; s|\.java$||' | tr '\n' ' ')
+          json_tests=$(echo "$tests[@]}" | jq -R -c 'split(" ")[:-1]')
+          echo "tests=$json_tests" >> $GITHUB_OUTPUT
+  integration-test:
+    needs:
+      - build
+      - list-integration-tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 8
+      matrix:
+        tests: ${{fromJson(needs.list-integration-tests.outputs.tests)}}
+    concurrency:
+      group: leangraph-${{ matrix.tests }}
+    name: "Integration"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifacts
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+          gradle-home-cache-cleanup: false
+          add-job-summary: on-failure
+      - name: Integration tests
+        env:
+          ATLAN_BASE_URL: ${{ secrets.LEANGRAPH_ATLAN_BASE_URL }}
+          ATLAN_API_KEY: ${{ secrets.LEANGRAPH_ATLAN_API_KEY }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/home/runner"
+        run: ./gradlew -PintegrationTests integration-tests:test --tests "com.atlan.java.sdk.${{ matrix.tests }}" -x assemble -x testClasses -x buildSrc:jar
+      - if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.tests }}
+          path: integration-tests/${{ matrix.tests }}.log
+  list-packages:
+    runs-on: ubuntu-latest
+    outputs:
+      tests: ${{ steps.test-directories.outputs.tests }}
+      asset-import-chunks: ${{ steps.asset-import-chunks.outputs.chunks }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: List package tests
+        id: test-directories
+        run: |
+          pkgs=$(find samples/packages -type d -mindepth 1 -maxdepth 1 | sed -E 's|samples/packages/||' | grep -v '^build$' | grep -v '^asset-import$' | tr '\n' ' ')
+          json_pkgs=$(echo "${pkgs[@]}" | jq -R -c 'split(" ")[:-1]')
+          echo "tests=$json_pkgs" >> $GITHUB_OUTPUT
+      - name: Create asset-import test chunks
+        id: asset-import-chunks
+        run: |
+          # Find all test classes
+          test_classes=$(find samples/packages/asset-import -name "*Test.kt" -type f | \
+            sed -E 's|samples/packages/asset-import/src/test/kotlin/||' | \
+            sed -E 's|/|.|g' | \
+            sed -E 's|.kt$||' | \
+            sort)
+          # Split into chunks of 10
+          chunks=$(echo "$test_classes" | jq -R -s -c '
+            split("\n")[:-1] |
+            [range(0; length; 10) as $i | .[$i:$i+10]] |
+            to_entries |
+            map({chunk: .key, tests: .value})
+          ')
+          echo "chunks=$chunks" >> $GITHUB_OUTPUT
+  asset-import-test:
+    needs:
+      - build
+      - list-packages
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 3
+      matrix:
+        include: ${{fromJson(needs.list-packages.outputs.asset-import-chunks)}}
+    name: "asset-import: chunk ${{ matrix.chunk }}"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifacts
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+          gradle-home-cache-cleanup: false
+          add-job-summary: on-failure
+      - name: Run test chunk
+        env:
+          ATLAN_BASE_URL: ${{ secrets.LEANGRAPH_ATLAN_BASE_URL }}
+          ATLAN_API_KEY: ${{ secrets.LEANGRAPH_ATLAN_API_KEY }}
+          CLIENT_ID: ${{ secrets.LEANGRAPH_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.LEANGRAPH_CLIENT_SECRET }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/home/runner"
+        run: |
+          test_args=$(echo '${{ toJson(matrix.tests) }}' | jq -r '.[] | "--tests " + .')
+          ./gradlew -PpackageTests :samples:packages:asset-import:test $test_args -x assemble -x testClasses -x buildSrc:jar
+      - if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: asset-import-chunk-${{ matrix.chunk }}
+          path: samples/packages/asset-import/**/debug.log
+  package-test:
+    needs:
+      - build
+      - list-packages
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        tests: ${{fromJson(needs.list-packages.outputs.tests)}}
+    concurrency:
+      group: leangraph-${{ matrix.tests }}
+    name: "Packages"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Download artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          name: build-artifacts
+      - uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654  # v5.2.0
+        with:
+          java-version: 21
+          distribution: temurin
+      - uses: gradle/actions/setup-gradle@v6
+        with:
+          cache-read-only: true
+          gradle-home-cache-cleanup: false
+          add-job-summary: on-failure
+      - name: Package tests
+        env:
+          ATLAN_BASE_URL: ${{ secrets.LEANGRAPH_ATLAN_BASE_URL }}
+          ATLAN_API_KEY: ${{ secrets.LEANGRAPH_ATLAN_API_KEY }}
+          CLIENT_ID: ${{ secrets.LEANGRAPH_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.LEANGRAPH_CLIENT_SECRET }}
+          NVD_API_KEY: ${{ secrets.NVD_API_KEY }}
+          JAVA_TOOL_OPTIONS: "-Djava.io.tmpdir=/home/runner"
+        run: ./gradlew -PpackageTests :samples:packages:${{ matrix.tests }}:test -x assemble -x testClasses -x buildSrc:jar
+      - if: success() || failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: ${{ matrix.tests }}
+          path: samples/packages/${{ matrix.tests }}/**/debug.log


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/test-leangraph.yml`, a parallel copy of `test.yml` that targets the **leangraph-test.atlan.com** tenant.
- Cron: `30 3 * * 1-5` — **09:00 IST (03:30 UTC) on weekdays only**. Does not overlap with the existing nightly `0 4 * * *` run.
- Also supports `workflow_dispatch` for on-demand runs.
- Uses dedicated `LEANGRAPH_*` repo secrets instead of the existing `ATLAN_*` / `CLIENT_*` ones, so the current daily pipeline is untouched.
- Concurrency groups are prefixed with `leangraph-` to avoid colliding with the existing workflow when both run at once.

## Required repo secrets (must be configured before the first run)
The following four secrets need to be set at the repo level for the workflow to actually authenticate against `leangraph-test.atlan.com`:

- `LEANGRAPH_ATLAN_BASE_URL` — e.g. `https://leangraph-test.atlan.com`
- `LEANGRAPH_ATLAN_API_KEY`
- `LEANGRAPH_CLIENT_ID`
- `LEANGRAPH_CLIENT_SECRET`

`NVD_API_KEY` is reused from the existing repo secret.

## Test plan
- [ ] Configure the four `LEANGRAPH_*` secrets via `gh secret set` (or the Settings UI).
- [ ] Trigger the new workflow manually via the **Run workflow** button on the Actions tab and confirm `build`, `integration-test`, `asset-import-test`, and `package-test` jobs all pick up the leangraph-test base URL.
- [ ] Verify the next weekday-09:00-IST scheduled run lands in the Actions log.
- [ ] Verify the existing `Test` workflow (`test.yml`) is unaffected and continues to use the original `ATLAN_BASE_URL`/`ATLAN_API_KEY` secrets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)