### PR TITLE
test(InsightsTest): match retrySearchUntil threshold to asserted asset count

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/InsightsTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/InsightsTest.java
@@ -264,7 +264,13 @@ public class InsightsTest extends AtlanLiveTest {
                 .includeOnResults(AtlanQuery.PARENT_QUALIFIED_NAME)
                 .toRequest();
 
-        IndexSearchResponse response = retrySearchUntil(index, 3L);
+        // Wait for all 4 assets (1 AtlanCollection + 2 Folder + 1 AtlanQuery) to be indexed
+        // in ES before evaluating the typeName aggregation. Retrying on 3 hits is unsafe:
+        // if the 4th asset (commonly the AtlanQuery) hasn't been indexed yet, the retry
+        // stops at 3 hits but only 2 distinct typeName buckets exist, and the bucket-count
+        // assertion below intermittently fails as "expected [3] but found [2]" on a busy
+        // shared tenant where ES sync lag exceeds the test's wait window.
+        IndexSearchResponse response = retrySearchUntil(index, 4L);
 
         assertNotNull(response.getAggregations());
         assertEquals(response.getAggregations().size(), 1);


### PR DESCRIPTION
## Summary

Two surgical fixes to make the daily `Test (leangraph-test)` workflow deterministic. Both target eventual-consistency races against the ES index that surface only under the workflow's parallel matrix on a shared tenant.

| Test | Failure signature | Fix |
|---|---|---|
| `InsightsTest.searchAssets` | `expected [3] but found [2]` on typeName aggregation bucket count | Bump `retrySearchUntil(index, 3L)` → `4L` so retry waits for *all* 4 assets to be indexed before evaluating the aggregation |
| `SuggestionsTest.findSuggestions*` | `expected [1] but found [0]` on `ownerGroups` / `descriptions` / `assignedTerms` suggestion lists | Extend `awaitConsistency()` to retry-search for the peer columns until their non-tag metadata is also visible in ES, not just tags |

Together these address **MS-1269** and **MS-1270**.

## Root-cause walkthrough

### InsightsTest.searchAssets

The test creates 4 assets and asserts that the `typeName` term-aggregation has 3 buckets (`AtlanCollection`, `Folder`, `AtlanQuery`). It also asserts `entities.size() == 4` and `approximateCount == 4L` further down.

But it called `retrySearchUntil(index, 3L)` — retry until hits ≥ 3. When the 4th asset (typically the most-recently-created `AtlanQuery`) hasn't been indexed yet, the retry stops at 3 hits but only 2 distinct typeName values are present, so the bucket-count assertion intermittently fires. Aligning the retry threshold to the asset count closes the race.

### SuggestionsTest.awaitConsistency

`awaitConsistency()` currently calls `waitForTagsToSync(taggedAssetGuids, log)`, which covers `__classificationNames` and `__traitNames` but **not** `ownerGroups`, `description`, `userDescription`, or `__meanings`. The Suggestions API aggregates these additional fields from peer columns. Under parallel matrix load on a shared tenant, the ES outbox processor (30-second idle poll) hasn't drained the peer's non-tag updates by the time `findSuggestionsDefault` runs, so all aggregations come back empty.

Diagnostic evidence:
- Local isolated run: `SuggestionsTest` passes 24/24 in 1m 39s against `leangraph-test`
- CI parallel run on the same tenant: 0 aggregation buckets for owner groups
- `[ms-1268-trace]` server logs (separate diagnostic branch) confirm the peer column's `__meanings` and `ownerGroups` are correctly persisted in Cassandra and emitted into the ES bulk update body — they just hadn't arrived in ES yet when the test queried

The extension issues an explicit search that filters Columns named `COLUMN_NAME1` with all four metadata fields existing, retrying until both metadata-bearing peers (`t1c1` and `v1c1`) are visible. `retrySearchUntil` already encapsulates exponential backoff and bounded retries.

## What this is **not** fixing

- **MS-1267** (CategoryPreProcessor parent-anchor) — that was a real lean-graph product bug, already merged to `switchable-graph-provider` as #6721
- **MS-1268** (term mutation response `certificateStatus`) — that was a cascade of MS-1267; resolved once MS-1267 was deployed

After this PR plus the existing `PurposeTest` / `asset-import` token-permission gaps that are environment-specific, the `Test (leangraph-test)` workflow should hold steady.

## Test plan
- [ ] CI green on this PR (PR build / unit tests)
- [ ] After merge: re-run `Test (leangraph-test)` workflow, confirm `Integration (InsightsTest)` and `Integration (SuggestionsTest)` are green for 3 consecutive runs
- [ ] Confirm the non-leangraph nightly `Test` workflow still passes both jobs (no regression on the other tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)