### PR TITLE
fix: proactively reject invalid connection qualifiedNames before Atlas POST (APP-2263)

### DIFF
--- a/samples/packages/asset-import/src/main/kotlin/com/atlan/pkg/aim/ConnectionImporter.kt
+++ b/samples/packages/asset-import/src/main/kotlin/com/atlan/pkg/aim/ConnectionImporter.kt
@@ -3,6 +3,8 @@
 package com.atlan.pkg.aim
 
 import AssetImportCfg
+import com.atlan.exception.ErrorCode
+import com.atlan.exception.InvalidRequestException
 import com.atlan.model.assets.Asset
 import com.atlan.model.assets.Connection
 import com.atlan.model.enums.AssetCreationHandling
@@ -12,6 +14,7 @@ import com.atlan.pkg.PackageContext
 import com.atlan.pkg.serde.RowDeserializer
 import com.atlan.pkg.serde.cell.AssetRefXformer.getDeferredIdentity
 import com.atlan.pkg.serde.csv.ImportResults
+import com.atlan.util.StringUtils
 import mu.KLogger
 import java.util.stream.Stream
 
@@ -114,6 +117,9 @@ class ConnectionImporter(
                 }
             // If a qualifiedName was sent explicitly, keep it (i.e., for connection widget passthrough or where multiple connections of the same type and name exist)
             if (deferredIdentity == null && qualifiedName.trim().isNotBlank()) {
+                if (!StringUtils.isValidConnectionQN(qualifiedName, true)) {
+                    throw InvalidRequestException(ErrorCode.INVALID_CONNECTION_QN, qualifiedName)
+                }
                 builder.qualifiedName(qualifiedName)
             }
             builder

--- a/sdk/src/main/java/com/atlan/exception/ErrorCode.java
+++ b/sdk/src/main/java/com/atlan/exception/ErrorCode.java
@@ -303,6 +303,11 @@ public enum ErrorCode implements ExceptionMessageSet {
             "ATLAN-JAVA-400-054",
             "Local credentials cannot be refreshed programmatically.",
             "You must create a new AtlanClient with the correct credentials."),
+    INVALID_CONNECTION_QN(
+            400,
+            "ATLAN-JAVA-400-055",
+            "Connection qualifiedName ''{0}'' is not valid: must be of the form ''default/connectorType/nnnnnnnnnn'' where connectorType contains only lowercase letters, digits, and hyphens.",
+            "The connectorType segment must match [a-z0-9-]+. Use hyphens instead of underscores or other special characters (for example, use ''dev-cmdr'' rather than ''dev_cmdr'')."),
 
     AUTHENTICATION_PASSTHROUGH(
             401,

--- a/sdk/src/main/java/com/atlan/model/assets/Connection.java
+++ b/sdk/src/main/java/com/atlan/model/assets/Connection.java
@@ -638,10 +638,14 @@ public class Connection extends Asset implements IConnection, IAsset, IReference
             List<String> adminUsers)
             throws AtlanException {
         boolean adminFound = false;
+        String qn = generateQualifiedName(connectorName);
+        if (!StringUtils.isValidConnectionQN(qn)) {
+            throw new InvalidRequestException(ErrorCode.INVALID_CONNECTION_QN, qn);
+        }
         ConnectionBuilder<?, ?> builder = Connection._internal()
                 .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
                 .name(name)
-                .qualifiedName(generateQualifiedName(connectorName))
+                .qualifiedName(qn)
                 .category(category)
                 .customConnectorType(connectorName);
         if (adminRoles != null && !adminRoles.isEmpty()) {

--- a/sdk/src/main/java/com/atlan/model/assets/_overlays/Connection.java
+++ b/sdk/src/main/java/com/atlan/model/assets/_overlays/Connection.java
@@ -196,10 +196,14 @@
             List<String> adminUsers)
             throws AtlanException {
         boolean adminFound = false;
+        String qn = generateQualifiedName(connectorName);
+        if (!StringUtils.isValidConnectionQN(qn)) {
+            throw new InvalidRequestException(ErrorCode.INVALID_CONNECTION_QN, qn);
+        }
         ConnectionBuilder<?, ?> builder = Connection._internal()
                 .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
                 .name(name)
-                .qualifiedName(generateQualifiedName(connectorName))
+                .qualifiedName(qn)
                 .category(category)
                 .customConnectorType(connectorName);
         if (adminRoles != null && !adminRoles.isEmpty()) {

--- a/sdk/src/test/java/com/atlan/util/StringUtilsTest.java
+++ b/sdk/src/test/java/com/atlan/util/StringUtilsTest.java
@@ -135,6 +135,21 @@ public class StringUtilsTest {
     }
 
     @Test
+    void invalidConnectionQN_underscoreInType() {
+        // Underscore in the connectorType segment is rejected — customers should use hyphens instead
+        final String test = "default/dev_cmdr/1234567890";
+        assertFalse(StringUtils.isValidConnectionQN(test));
+        assertFalse(StringUtils.isValidConnectionQN(test, true));
+    }
+
+    @Test
+    void invalidConnectionQN_upperCaseInType() {
+        final String test = "default/SNOWFLAKE/1234567890";
+        assertFalse(StringUtils.isValidConnectionQN(test));
+        assertFalse(StringUtils.isValidConnectionQN(test, true));
+    }
+
+    @Test
     void validRelaxedQN() {
         final String qn = StringUtils.getConnectionQualifiedName(qualifiedNameRelaxed1, true);
         assertNotNull(qn);


### PR DESCRIPTION
## Summary

- Adds `ErrorCode.INVALID_CONNECTION_QN` (`ATLAN-JAVA-400-055`) with a message directing customers to use hyphens instead of underscores in the connectorType segment
- **Layer 1 (SDK):** `Connection.creator()` for custom String connectorName now validates the synthesized `qualifiedName` via `StringUtils.isValidConnectionQN` before building the entity — throws `InvalidRequestException(INVALID_CONNECTION_QN)` client-side, before any Atlas POST. Covers `cab/ConnectionImporter` and `AbstractCrawler` callers.
- **Layer 2 (aim):** `ConnectionImporter.getBuilder()` validates any CSV-supplied `qualifiedName` override before applying it to the builder — no Atlas POST occurs for a malformed connection. Covers asset-import and all RAB workflows (which pipe through `com.atlan.pkg.aim.Importer`).

## Context

APP-2263 — customer hit a phantom Connection orphan when using connectorType `dev_cmdr` (underscore) in Relational Assets Builder. Atlas accepted the entity; the SDK validator rejected it afterwards; the import threw `IllegalStateException` with the Connection already persisted and unreachable through standard delete paths.

This is Hardening #3 from the ticket: fail fast client-side so no orphan is ever created. The regex itself is unchanged — underscore remains invalid; customers should use hyphens (`dev-cmdr`).

## Test plan

- [ ] `./gradlew :sdk:test --tests "com.atlan.util.StringUtilsTest"` — 16 tests pass, including 2 new regression guards pinning that underscore and uppercase in connectorType are rejected
- [ ] `./gradlew :sdk:test` — full 415-test SDK suite passes
- [ ] `./gradlew :samples:packages:asset-import:compileKotlin` — Kotlin compiles cleanly
- [ ] Manual: run customer's reproducer CSV (`qualifiedName=default/dev_cmdr/<epoch>`) through `com.atlan.pkg.aim.Importer.main` and confirm `InvalidRequestException` fires before any Atlas POST, with no phantom Connection left behind

🤖 Generated with [Claude Code](https://claude.com/claude-code)