### PR TITLE
test(SuggestionsTest): wait for non-tag peer metadata in awaitConsistency

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/SuggestionsTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/SuggestionsTest.java
@@ -405,11 +405,7 @@ public class SuggestionsTest extends AtlanLiveTest {
         // CI matrix load (expected [1] but found [0]).
         IndexSearchRequest peerReady = client.assets
                 .select()
-                .where(Asset.GUID.in(List.of(
-                        table1.getGuid(),
-                        table3.getGuid(),
-                        t1c1.getGuid(),
-                        v1c1.getGuid())))
+                .where(Asset.GUID.in(List.of(table1.getGuid(), table3.getGuid(), t1c1.getGuid(), v1c1.getGuid())))
                 .where(Asset.OWNER_GROUPS.hasAnyValue())
                 .where(Asset.ASSIGNED_TERMS.hasAnyValue())
                 .pageSize(0)

--- a/integration-tests/src/test/java/com/atlan/java/sdk/SuggestionsTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/SuggestionsTest.java
@@ -390,6 +390,31 @@ public class SuggestionsTest extends AtlanLiveTest {
             dependsOnGroups = {"suggestions.update.column.*"})
     void awaitConsistency() throws AtlanException, InterruptedException {
         waitForTagsToSync(taggedAssetGuids, log);
+
+        // waitForTagsToSync only covers the classification denorm. The three find* test
+        // methods below also aggregate ownerGroups / descriptions / assignedTerms, none
+        // of which the tag-sync helper waits on. Wait until all four assets that received
+        // those updates show ownerGroups + assignedTerms visible in ES:
+        //   - table1  (peer for findLimitedSuggestions on table2, matched by TABLE_NAME)
+        //   - table3  (peer for findSuggestionsAcrossTypes on view1, matched by VIEW_NAME)
+        //   - t1c1    (peer for findSuggestionsDefault on t2c1,    matched by COLUMN_NAME1)
+        //   - v1c1    (second peer for findSuggestionsDefault,     matched by COLUMN_NAME1)
+        // retrySearchUntil expects the matching count to reach the threshold within the
+        // configured network retries — bounded backoff, no busy-wait. Without this guard
+        // the three findSuggestions* tests intermittently get empty aggregations under
+        // CI matrix load (expected [1] but found [0]).
+        IndexSearchRequest peerReady = client.assets
+                .select()
+                .where(Asset.GUID.in(List.of(
+                        table1.getGuid(),
+                        table3.getGuid(),
+                        t1c1.getGuid(),
+                        v1c1.getGuid())))
+                .where(Asset.OWNER_GROUPS.hasAnyValue())
+                .where(Asset.ASSIGNED_TERMS.hasAnyValue())
+                .pageSize(0)
+                .toRequest();
+        retrySearchUntil(peerReady, 4L);
     }
 
     @Test(


### PR DESCRIPTION
## Summary

`SuggestionsTest.awaitConsistency` previously only waited for tag denormalisation via `waitForTagsToSync`. The three `findSuggestions*` test methods that follow aggregate on additional non-tag fields (`ownerGroups`, `description`, `userDescription`, `assignedTerms`) which weren't being waited on, so under CI matrix load the queries fired before the peer assets' metadata reached the ES search index → empty aggregations → `expected [1] but found [0]`.

This PR extends `awaitConsistency` to also wait until the four metadata-bearing peers (`table1`, `table3`, `t1c1`, `v1c1`) show `ownerGroups + assignedTerms` visible in ES.

## Diagnosis path

| Step | Result |
|---|---|
| `SuggestionsTest` run in isolation against `leangraph-test` | 24/24 pass, 1m 39s |
| Daily `Test (leangraph-test)` workflow, full matrix (8/3/5) | 3 sub-failures: `findSuggestionsDefault`, `findSuggestionsAcrossTypes`, `findLimitedSuggestions` |
| Same workflow, **reduced matrix to 2/2/2** ([run 26027064093](https://github.com/atlanhq/atlan-java/actions/runs/26027064093)) | **Same 3 sub-failures still fail** — confirms even modest concurrent write contention triggers the race |
| Server-side trace (`[ms-1268-trace]` instrumentation) | Confirms peer metadata is correctly persisted in Cassandra and emitted into the ES bulk update body — the race is purely about ES refresh visibility, not data loss |

The 2-way reproduction was the deciding evidence: high parallelism isn't required; the race window between commit and search just needs to land below ES's refresh tick (default 1s) for *any* concurrent write workload.

## Why test-side wait, not server-side

A server-side change (`?refresh=wait_for` on the inline ES bulk) was considered in [atlas-metastore#6727](https://github.com/atlanhq/atlas-metastore/pull/6727). Closed without merging due to performance concerns under bulk-import load (the `index.max_refresh_listeners` ceiling of 1000 can flip `wait_for` into forced-refresh behaviour when many writers stack up concurrently, fragmenting segments). Tests should wait for their explicit preconditions rather than rely on implicit server timing guarantees.

## What this is **not** trying to fix

- `Integration (PurposeTest)` / `asset-import: chunk 0/1/3` token-permission failures — separate
- `Integration (SearchTest)` — pre-existing failure on both lean-graph and legacy tenants
- `Packages (duplicate-detector)` / `Packages (cube-assets-builder)` — separate flake/permission territory

## Test plan
- [ ] CI build green (PR build)
- [ ] After merge: `Integration (SuggestionsTest)` job green for 3 consecutive daily `Test (leangraph-test)` runs
- [ ] Non-leangraph nightly `Test` workflow still passes `Integration (SuggestionsTest)` (no regression on the other tenant)

## Linear

Resolves part of MS-1270 (the ES refresh race manifesting as Suggestions failures). MS-1270 to be closed once 3 consecutive daily runs are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)