### PR TITLE
fix(csa-asset-import): disable OTEL SDK to prevent JVM shutdown crash

### DIFF
--- a/samples/packages/asset-import/src/main/resources/package.pkl
+++ b/samples/packages/asset-import/src/main/resources/package.pkl
@@ -16,6 +16,7 @@ containerCommand {
   "/dumb-init"
   "--"
   "java"
+  "-Dotel.sdk.disabled=true"
   "com.atlan.pkg.aim.Importer"
 }
 outputs {


### PR DESCRIPTION
## Summary

- The `opentelemetry-instrumentation-log4j-appender` dependency has a binary incompatibility: `LogEventMapper` references `OTEL_EVENT_NAME` which does not exist in the runtime OTEL API version
- This throws `NoSuchFieldError` during JVM shutdown when Log4j flushes its appenders, causing the process to exit with code 1 even when the import itself completed successfully
- Argo marks these runs as **Failed** (instead of Succeeded), which prevents the workflow overview UI from reading import counts from the results artifact

**Fix:** Add `-Dotel.sdk.disabled=true` to the JVM args in `containerCommand`. This prevents OTEL SDK initialization, stopping the instrumented Log4j appender from registering and eliminating the shutdown crash.

**Affected file:** `samples/packages/asset-import/src/main/resources/package.pkl`

## Test plan

- [ ] Build and publish a SNAPSHOT image with this change
- [ ] Update the `csa-asset-import` ClusterWorkflowTemplate on a test tenant (e.g. fs3.atlan.com) to use the new image
- [ ] Run the workflow with test CSV files
- [ ] Verify the run phase is **Succeeded** (not Failed)
- [ ] Verify the workflow overview tab shows non-zero import counts

## Notes

This is a short-term fix. The proper long-term fix is to align OTEL dependency versions using `opentelemetry-bom` in the Gradle build for this package, so the instrumentation and API jars are compatible at runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)