### PR TITLE
fix(asset-export-basic): preload domain cache to fix truncated hierarchy paths (CSA-444)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'fix/csa-444-preload-domain-cache']
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -6,7 +6,7 @@ permissions:
 
 on:
   push:
-    branches: [main, 'fix/csa-444-preload-domain-cache']
+    branches: [main]
   workflow_dispatch:
     inputs:
       branch:
@@ -246,7 +246,6 @@ jobs:
       contents: read
       packages: write
     strategy:
-      fail-fast: false
       matrix:
         package_name:
           - api-token-connection-admin

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -246,6 +246,7 @@ jobs:
       contents: read
       packages: write
     strategy:
+      fail-fast: false
       matrix:
         package_name:
           - api-token-connection-admin

--- a/samples/packages/asset-export-basic/src/main/kotlin/MeshExporter.kt
+++ b/samples/packages/asset-export-basic/src/main/kotlin/MeshExporter.kt
@@ -47,6 +47,12 @@ class MeshExporter(
             csv.writeHeader(headerNames)
             val start = System.currentTimeMillis()
 
+            // Preload the domain cache up-front so identities resolve in level-order
+            // (parents-before-children). Without this, mid-tier domains lazy-loaded
+            // before their parent are cached with truncated identities, producing
+            // 1-level-short hierarchy paths in the export (CSA-444).
+            ctx.dataDomainCache.preload()
+
             // Retrieve all domains up-front
             val domains =
                 DataDomain

--- a/samples/packages/asset-export-basic/src/test/kotlin/ExportDomainHierarchyTest.kt
+++ b/samples/packages/asset-export-basic/src/test/kotlin/ExportDomainHierarchyTest.kt
@@ -1,0 +1,123 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2025 Atlan Pte. Ltd. */
+import com.atlan.model.assets.DataDomain
+import com.atlan.model.assets.DataProduct
+import com.atlan.model.assets.GlossaryTerm
+import com.atlan.pkg.PackageTest
+import com.atlan.pkg.Utils
+import com.atlan.pkg.serde.cell.DataDomainXformer.DATA_DOMAIN_DELIMITER
+import de.siegmar.fastcsv.reader.CsvReader
+import de.siegmar.fastcsv.reader.FieldMismatchStrategy
+import org.testng.annotations.Test
+import java.nio.file.Paths
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+/*
+ * Regression test for CSA-444: domain hierarchy paths must not be truncated for
+ * mid-tier domains. Builds a 3-level domain hierarchy (grandparent > parent > child)
+ * with a data product under the deepest child, then verifies the mesh export
+ * resolves full level-order identities (parents before children) rather than the
+ * 1-level-short paths produced when the domain cache is not preloaded.
+ */
+class ExportDomainHierarchyTest : PackageTest("edh") {
+    override val logger = Utils.getLogger(this.javaClass.name)
+
+    private val grandparent = makeUnique("gp")
+    private val parent = makeUnique("p")
+    private val child = makeUnique("c")
+    private val product = makeUnique("prod")
+
+    // Expected, fully-qualified hierarchy identities (parents-before-children).
+    private val parentIdentity = "$grandparent$DATA_DOMAIN_DELIMITER$parent"
+    private val childIdentity = "$parentIdentity$DATA_DOMAIN_DELIMITER$child"
+
+    private val files =
+        listOf(
+            "products-export.csv",
+            "debug.log",
+        )
+
+    private fun createHierarchy() {
+        val gp = DataDomain.creator(grandparent).build()
+        val gpResult = gp.save(client).getResult(gp)
+        val p = DataDomain.creator(parent, gpResult.qualifiedName).build()
+        val pResult = p.save(client).getResult(p)
+        val c = DataDomain.creator(child, pResult.qualifiedName).build()
+        val cResult = c.save(client).getResult(c)
+        val dp =
+            DataProduct
+                .creator(client, product, cResult.qualifiedName, GlossaryTerm.select(client).build())
+                .build()
+        dp.save(client).getResult(dp)
+    }
+
+    override fun setup() {
+        createHierarchy()
+        // Ensure the freshly-created assets are searchable before exporting.
+        retrySearchUntil(DataDomain.select(client).where(DataDomain.NAME.eq(child)).toRequest(), 1)
+        retrySearchUntil(DataProduct.select(client).where(DataProduct.NAME.eq(product)).toRequest(), 1)
+        runCustomPackage(
+            AssetExportBasicCfg(
+                exportScope = "PRODUCTS_ONLY",
+                includeGlossaries = false,
+                includeProducts = true,
+            ),
+            Exporter::main,
+        )
+    }
+
+    override fun teardown() {
+        removeDomainAndChildren(grandparent)
+    }
+
+    @Test
+    fun filesCreated() {
+        validateFilesExist(files)
+    }
+
+    @Test
+    fun errorFreeLog() {
+        validateErrorFreeLog()
+    }
+
+    @Test
+    fun hierarchyNotTruncated() {
+        val exportFile = Paths.get(testDirectory, "products-export.csv")
+        val records =
+            CsvReader
+                .builder()
+                .fieldSeparator(',')
+                .quoteCharacter('"')
+                .skipEmptyLines(true)
+                .missingFieldStrategy(FieldMismatchStrategy.STRICT)
+                .extraFieldStrategy(FieldMismatchStrategy.STRICT)
+                .ofCsvRecord(exportFile)
+                .stream()
+                .toList()
+
+        val header = records.first().fields
+        val nameIdx = header.indexOf("name")
+        val typeIdx = header.indexOf("typeName")
+        val parentDomainIdx = header.indexOf("parentDomain")
+        val dataDomainIdx = header.indexOf("dataDomain")
+        assert(nameIdx != -1) { "Column 'name' not found in export" }
+        assert(typeIdx != -1) { "Column 'typeName' not found in export" }
+        assert(parentDomainIdx != -1) { "Column 'parentDomain' not found in export" }
+        assert(dataDomainIdx != -1) { "Column 'dataDomain' not found in export" }
+
+        val rows = records.drop(1)
+
+        // Mid-tier child domain must carry the full parent path, not a truncated 1-level path.
+        val childRow =
+            rows.firstOrNull { it.fields[typeIdx] == DataDomain.TYPE_NAME && it.fields[nameIdx] == child }
+        assertNotNull(childRow, "Child domain row '$child' missing from export")
+        assertEquals(parentIdentity, childRow.fields[parentDomainIdx], "Child domain parent path truncated")
+
+        // Product under the deepest domain must reference the full 3-level domain identity.
+        val productRow =
+            rows.firstOrNull { it.fields[typeIdx] == DataProduct.TYPE_NAME && it.fields[nameIdx] == product }
+        assertNotNull(productRow, "Product row '$product' missing from export")
+        assertEquals(childIdentity, productRow.fields[dataDomainIdx], "Product domain path truncated")
+    }
+}


### PR DESCRIPTION
## What & why

JPMC's CSA Asset Export produced **truncated domain hierarchy paths** for mid-tier domains — e.g. a Data Product under `Risk Management and Compliance > Wholesale Credit Risk` exported as `Wholesale Credit Risk@<product>` instead of `Risk Management and Compliance@Wholesale Credit Risk@<product>`. The tenant data was correct; the bug was in the exporter.

Linear: [CSA-444](https://linear.app/atlan-epd/issue/CSA-444/asset-export-basic-domain-hierarchy-paths-truncated-to-1-level-for-mid)

## Root cause

`MeshExporter.export()` never called `ctx.dataDomainCache.preload()`. Without it, domains were lazy-loaded one-at-a-time (`getByGuid → lookupById`) in **GUID order**, not parent-before-child order. When a mid-tier domain was looked up *before* its parent was cached, `getIdentityForAsset` resolved the parent identity via `getIdentity(parentGuid, bypassReadLock=true)` — which is **non-recursive and does not lookup-on-miss** — so it returned blank and the domain was cached with a 1-level-short identity. Every product/sub-domain referencing it then inherited the truncated path.

Only `DataDomainCache.refreshCache()` loads domains in level-order (roots first, then children sorted by parent QN), and it runs **only** inside `preload()`. Sibling packages already call it (`asset-import/AbstractBaseImporter.kt`, `cube-assets-builder/Importer.kt`); `asset-export-basic` was the only mesh-touching package missing it.

## The fix

One line in `MeshExporter.export()`, before the export loop:

```kotlin
ctx.dataDomainCache.preload()
```

This loads the domain cache up-front in parents-before-children order. `preload()` is `@Synchronized` and idempotent; the cost is one bulk paged scan instead of N individual `size=1` lookups (net cheaper).

## Tests

Added `ExportDomainHierarchyTest` — builds a 3-level domain hierarchy (grandparent → parent → child) with a data product under the deepest child and asserts the export resolves full level-order identities (not truncated).

## Verification on a live tenant

Built a snapshot image (`ghcr.io/atlanhq/csa-asset-export-basic:7.2.4-SNAPSHOT`), deployed to `apps-typedef.atlan.com`, created a 3-level fixture (`D3 → SD1 → CSA444-Leaf` with `CSA444-Product`), and ran the export.

**Test workflow run:** https://apps-typedef.atlan.com/api/orchestration/workflows/default/csa-asset-export-basic-csa444-mctgz

Result in `products-export.csv`:

| Row | Column | Value |
|---|---|---|
| `CSA444-Product` (DataProduct) | `dataDomain` | `D3@SD1@CSA444-Leaf` ✅ full 3-level |
| `CSA444-Leaf` (DataDomain) | `parentDomain` | `D3@SD1` ✅ |
| `SD1` (DataDomain) | `parentDomain` | `D3` ✅ |

Mid-tier domains now resolve to their full root-to-leaf identity. Before the fix, `CSA444-Product` would have shown `SD1@CSA444-Leaf` / `CSA444-Leaf`.

## Follow-up

`atlanhq/marketplace-packages` needs its `csa-asset-export-basic` image bumped to a released version once this lands and a tagged build is published (tracked under CSA-444).


[CSA-444]: https://atlanhq.atlassian.net/browse/CSA-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ