### PR TITLE
Fix CONNECT-50: set qualifiedName in version-agnostic Model creators

### DIFF
--- a/sdk/src/main/java/com/atlan/model/assets/ModelAttribute.java
+++ b/sdk/src/main/java/com/atlan/model/assets/ModelAttribute.java
@@ -528,6 +528,7 @@ public class ModelAttribute extends Asset implements IModelAttribute, IModel, IC
                 .modelEntityQualifiedName(entityQualifiedName)
                 .modelAttributeEntity(ModelEntity.refByQualifiedName(entityQualifiedName, SaveSemantic.APPEND))
                 .modelVersionAgnosticQualifiedName(generateQualifiedName(name, entityQualifiedName))
+                .qualifiedName(generateQualifiedName(name, entityQualifiedName))
                 .modelType(modelType)
                 .connectionQualifiedName(connectionQualifiedName);
     }

--- a/sdk/src/main/java/com/atlan/model/assets/ModelEntity.java
+++ b/sdk/src/main/java/com/atlan/model/assets/ModelEntity.java
@@ -518,6 +518,7 @@ public class ModelEntity extends Asset implements IModelEntity, IModel, ICatalog
                 .modelQualifiedName(modelQualifiedName)
                 .modelType(modelType)
                 .modelVersionAgnosticQualifiedName(generateQualifiedName(name, modelQualifiedName))
+                .qualifiedName(generateQualifiedName(name, modelQualifiedName))
                 .connectionQualifiedName(connectionQualifiedName);
     }
 

--- a/sdk/src/main/java/com/atlan/model/assets/_overlays/ModelAttribute.java
+++ b/sdk/src/main/java/com/atlan/model/assets/_overlays/ModelAttribute.java
@@ -70,6 +70,7 @@
                 .modelEntityQualifiedName(entityQualifiedName)
                 .modelAttributeEntity(ModelEntity.refByQualifiedName(entityQualifiedName, SaveSemantic.APPEND))
                 .modelVersionAgnosticQualifiedName(generateQualifiedName(name, entityQualifiedName))
+                .qualifiedName(generateQualifiedName(name, entityQualifiedName))
                 .modelType(modelType)
                 .connectionQualifiedName(connectionQualifiedName);
     }

--- a/sdk/src/main/java/com/atlan/model/assets/_overlays/ModelEntity.java
+++ b/sdk/src/main/java/com/atlan/model/assets/_overlays/ModelEntity.java
@@ -62,6 +62,7 @@
                 .modelQualifiedName(modelQualifiedName)
                 .modelType(modelType)
                 .modelVersionAgnosticQualifiedName(generateQualifiedName(name, modelQualifiedName))
+                .qualifiedName(generateQualifiedName(name, modelQualifiedName))
                 .connectionQualifiedName(connectionQualifiedName);
     }
 

--- a/sdk/src/test/java/com/atlan/model/assets/ModelCreatorTest.java
+++ b/sdk/src/test/java/com/atlan/model/assets/ModelCreatorTest.java
@@ -1,0 +1,69 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2024 Atlan Pte. Ltd. */
+package com.atlan.model.assets;
+
+import static org.testng.Assert.*;
+
+import com.atlan.exception.AtlanException;
+import com.atlan.model.enums.DataModelType;
+import org.testng.annotations.Test;
+
+/**
+ * Regression tests for CONNECT-50 / BLDX-1482.
+ *
+ * <p>The version-agnostic {@code ModelEntity.creator(...)} and {@code ModelAttribute.creator(...)}
+ * overloads used to set only {@code modelVersionAgnosticQualifiedName} and never {@code qualifiedName}.
+ * Since {@code qualifiedName} is a mandatory primary key for Model assets (and is generated
+ * client-side, not derived server-side on the non-versioned path), creating these assets without a
+ * {@code modelBusinessDate} silently failed at {@code POST /api/meta/entity/bulk}.
+ *
+ * <p>These are pure builder assertions -- no live tenant -- deliberately exercising the
+ * <b>non-versioned</b> path (no {@code modelBusinessDate}), which the integration tests never covered.
+ */
+public class ModelCreatorTest {
+
+    private static final String CONNECTION_QN = "default/model/1234567890";
+    private static final String MODEL_NAME = "CDO";
+    private static final String MODEL_TYPE = DataModelType.LOGICAL.toString();
+
+    private static ModelDataModel model() {
+        return ModelDataModel.creator(MODEL_NAME, CONNECTION_QN, DataModelType.LOGICAL)
+                .build();
+    }
+
+    @Test
+    void entityCreatorFromModelSetsQualifiedName() throws AtlanException {
+        ModelDataModel model = model();
+        ModelEntity entity = ModelEntity.creator("MessageBase", model).build();
+        assertNotNull(
+                entity.getQualifiedName(),
+                "qualifiedName must be set on the version-agnostic entity creator (CONNECT-50).");
+        assertEquals(
+                entity.getQualifiedName(),
+                entity.getModelVersionAgnosticQualifiedName(),
+                "qualifiedName should mirror modelVersionAgnosticQualifiedName, matching the other Model* creators.");
+        assertTrue(entity.getQualifiedName().startsWith(model.getQualifiedName() + "/"));
+    }
+
+    @Test
+    void entityCreatorFromModelQualifiedNameSetsQualifiedName() {
+        String modelQualifiedName = CONNECTION_QN + "/" + MODEL_NAME;
+        ModelEntity entity = ModelEntity.creator("MessageBase", modelQualifiedName, MODEL_TYPE)
+                .build();
+        assertNotNull(entity.getQualifiedName(), "qualifiedName must be set on the 3-arg entity creator (CONNECT-50).");
+        assertEquals(entity.getQualifiedName(), entity.getModelVersionAgnosticQualifiedName());
+        assertTrue(entity.getQualifiedName().startsWith(modelQualifiedName + "/"));
+    }
+
+    @Test
+    void attributeCreatorSetsQualifiedName() {
+        String entityQualifiedName = CONNECTION_QN + "/" + MODEL_NAME + "/messagebase";
+        ModelAttribute attribute = ModelAttribute.creator("CorrelationId", entityQualifiedName, MODEL_TYPE)
+                .build();
+        assertNotNull(
+                attribute.getQualifiedName(),
+                "qualifiedName must be set on the version-agnostic attribute creator (CONNECT-50).");
+        assertEquals(attribute.getQualifiedName(), attribute.getModelVersionAgnosticQualifiedName());
+        assertTrue(attribute.getQualifiedName().startsWith(entityQualifiedName + "/"));
+    }
+}


### PR DESCRIPTION
## Problem

The version-agnostic `ModelEntity.creator(...)` and `ModelAttribute.creator(...)` overloads set `modelVersionAgnosticQualifiedName` but never set `qualifiedName`. Since `qualifiedName` is a mandatory, client-generated primary key for Model assets on the non-versioned path, creating these assets **without** a `modelBusinessDate` failed silently at `POST /api/meta/entity/bulk` (timeout, no error).

Reported by CME Group (cmegroup-uat) via [CONNECT-50](https://linear.app/atlan-epd/issue/CONNECT-50) / ZD-125710. Customer-confirmed that appending `.qualifiedName(...)` manually resolves it.

## Fix

Set `qualifiedName` to the same generated value as `modelVersionAgnosticQualifiedName` — one line in each creator. This matches `creatorForVersion` and **every** other `Model*` creator, notably `ModelEntityAssociation.creator`, which already sets both keys and is exercised alongside `modelBusinessDate` in the integration tests — proving the combination is compatible with the server-side versioning path.

Applied to both the `_overlays/` sources (canonical) and the generated mirrors so it ships without waiting for a `atlanhq/models` → `atlan-java` re-sync.

All 2-/3-arg overloads delegate to the 5-arg creator, so this covers every entry point the customer tried.

## Blast radius

Low.
- Non-versioned users (the reported case): currently broken → fixed.
- Versioned users (`modelBusinessDate` set): payload now includes `qualifiedName`, proven compatible by the sibling association creator.
- Users already appending `.qualifiedName(...)` as a workaround: their explicit builder call still wins → no change.

## Tests

Adds `ModelCreatorTest` (pure builder assertions, no live tenant) covering the **non-versioned** path with no `modelBusinessDate` — the exact coverage gap that let this regress, since `ModelTest` only ever exercises the creators with `modelBusinessDate` set. Asserts `qualifiedName` is non-null, equals `modelVersionAgnosticQualifiedName`, and is rooted under the parent QN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)