### PR TITLE
fix(asset-import): decode input CSVs UTF-8-first with cp1252 fallback (CSA-458)

### DIFF
--- a/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/csv/CSVEncoding.kt
+++ b/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/csv/CSVEncoding.kt
@@ -1,0 +1,87 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2026 Atlan Pte. Ltd. */
+package com.atlan.pkg.serde.csv
+
+import java.io.BufferedInputStream
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.Reader
+import java.nio.charset.Charset
+import java.nio.file.Files
+import java.nio.file.Path
+
+/**
+ * Opens input CSV files for reading with encoding handling that avoids silently corrupting non-ASCII
+ * content.
+ *
+ * Historically the readers passed a [Path] straight to FastCSV, which decodes as UTF-8 using the
+ * JDK's default decoder behaviour -- that *silently* substitutes any byte which is not valid UTF-8
+ * with the Unicode replacement character (U+FFFD). Files produced by common tools (most notably
+ * Excel's "Save As -> CSV" on Windows, which writes Windows-1252) were therefore corrupted, e.g. the
+ * ellipsis '…' (the single byte 0x85 in cp1252) became U+FFFD.
+ *
+ * Strategy:
+ *  - If the file starts with a UTF-16 or UTF-32 BOM, decode with that (BOM-aware) charset.
+ *  - Otherwise decode UTF-8-first with a per-byte Windows-1252 fallback (see
+ *    [Utf8WithCp1252FallbackReader]), which correctly handles clean UTF-8, clean cp1252, and the
+ *    mixed-encoding files seen in the wild. A leading UTF-8 BOM, if present, is skipped.
+ */
+object CSVEncoding {
+    private val UTF_8_BOM = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte())
+
+    /**
+     * Open the provided CSV file as a character stream, decoding it losslessly.
+     *
+     * @param path location of the CSV file to read
+     * @return a [Reader] positioned at the first content character (after any BOM)
+     */
+    fun open(path: Path): Reader {
+        val bom = readLeadingBytes(path, 4)
+        detectBomCharset(bom)?.let { charset ->
+            // UTF-16/UTF-32 charsets consume their own BOM; hand the raw stream to an InputStreamReader.
+            return InputStreamReader(BufferedInputStream(Files.newInputStream(path)), charset)
+        }
+        val stream = BufferedInputStream(Files.newInputStream(path))
+        if (startsWith(bom, UTF_8_BOM)) {
+            // Skip the UTF-8 BOM bytes so they do not surface as a stray U+FEFF in the first field.
+            stream.skipNBytes(UTF_8_BOM.size.toLong())
+        }
+        return Utf8WithCp1252FallbackReader(stream)
+    }
+
+    private fun readLeadingBytes(
+        path: Path,
+        count: Int,
+    ): ByteArray {
+        val buffer = ByteArray(count)
+        val read =
+            Files.newInputStream(path).use { input ->
+                input.read(buffer)
+            }
+        return if (read <= 0) ByteArray(0) else buffer.copyOf(read)
+    }
+
+    /** Detect a UTF-16/UTF-32 BOM (UTF-8 BOM is handled separately, as it does not change the decoder). */
+    private fun detectBomCharset(bom: ByteArray): Charset? {
+        fun b(i: Int): Int = if (i < bom.size) bom[i].toInt() and 0xFF else -1
+        return when {
+            // UTF-32 BOMs must be checked before UTF-16 LE, since they share the 0xFF 0xFE prefix.
+            b(0) == 0xFF && b(1) == 0xFE && b(2) == 0x00 && b(3) == 0x00 -> Charset.forName("UTF-32")
+            b(0) == 0x00 && b(1) == 0x00 && b(2) == 0xFE && b(3) == 0xFF -> Charset.forName("UTF-32")
+            b(0) == 0xFF && b(1) == 0xFE -> Charset.forName("UTF-16")
+            b(0) == 0xFE && b(1) == 0xFF -> Charset.forName("UTF-16")
+            else -> null
+        }
+    }
+
+    private fun startsWith(
+        data: ByteArray,
+        prefix: ByteArray,
+    ): Boolean {
+        if (data.size < prefix.size) return false
+        for (i in prefix.indices) {
+            if (data[i] != prefix[i]) return false
+        }
+        return true
+    }
+}

--- a/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/csv/CSVReader.kt
+++ b/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/csv/CSVReader.kt
@@ -78,9 +78,11 @@ class CSVReader
                     .quoteCharacter('"')
                     .skipEmptyLines(true)
                     .ignoreDifferentFieldCount(false)
-            reader = builder.ofCsvRecord(inputFile)
-            counter = builder.ofCsvRecord(inputFile)
-            preproc = builder.ofCsvRecord(inputFile)
+            // Open via CSVEncoding so non-UTF-8 files (e.g. Excel-on-Windows cp1252, or mixed-encoding
+            // files) are decoded losslessly rather than silently corrupted into U+FFFD characters.
+            reader = builder.ofCsvRecord(CSVEncoding.open(inputFile))
+            counter = builder.ofCsvRecord(CSVEncoding.open(inputFile))
+            preproc = builder.ofCsvRecord(CSVEncoding.open(inputFile))
         }
 
         /**

--- a/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/csv/CSVXformer.kt
+++ b/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/csv/CSVXformer.kt
@@ -37,7 +37,6 @@ abstract class CSVXformer(
     private val header: List<String>
 
     init {
-        val input = Paths.get(inputFile)
         val builder =
             CsvReader
                 .builder()
@@ -46,8 +45,10 @@ abstract class CSVXformer(
                 .skipEmptyLines(true)
                 .ignoreDifferentFieldCount(false)
         header = getHeader(inputFile, fieldSeparator)
-        reader = builder.ofCsvRecord(input)
-        counter = builder.ofCsvRecord(input)
+        // Open via CSVEncoding so non-UTF-8 files (e.g. Excel-on-Windows cp1252, or mixed-encoding
+        // files) are decoded losslessly rather than silently corrupted into U+FFFD characters.
+        reader = builder.ofCsvRecord(CSVEncoding.open(Paths.get(inputFile)))
+        counter = builder.ofCsvRecord(CSVEncoding.open(Paths.get(inputFile)))
     }
 
     companion object {
@@ -62,7 +63,6 @@ abstract class CSVXformer(
             file: String,
             fieldSeparator: Char = ',',
         ): List<String> {
-            val input = Paths.get(file)
             val builder =
                 CsvReader
                     .builder()
@@ -70,7 +70,7 @@ abstract class CSVXformer(
                     .quoteCharacter('"')
                     .skipEmptyLines(true)
                     .ignoreDifferentFieldCount(false)
-            builder.ofCsvRecord(input).use { tmp ->
+            builder.ofCsvRecord(CSVEncoding.open(Paths.get(file))).use { tmp ->
                 val one = tmp.stream().findFirst()
                 return one
                     .map { obj: CsvRecord ->

--- a/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/csv/Utf8WithCp1252FallbackReader.kt
+++ b/package-toolkit/runtime/src/main/kotlin/com/atlan/pkg/serde/csv/Utf8WithCp1252FallbackReader.kt
@@ -1,0 +1,101 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2026 Atlan Pte. Ltd. */
+package com.atlan.pkg.serde.csv
+
+import java.io.BufferedInputStream
+import java.io.InputStream
+import java.io.PushbackInputStream
+import java.io.Reader
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+
+/**
+ * A streaming [Reader] that decodes bytes as UTF-8 wherever they form a valid UTF-8 sequence, and
+ * falls back to Windows-1252 (cp1252) for any individual byte that does not.
+ *
+ * Real-world CSVs (particularly those edited/exported through Excel on Windows) are frequently
+ * *mixed* encoding: mostly cp1252 with the occasional genuine UTF-8 sequence, or vice versa. A
+ * single whole-file charset choice therefore always mangles part of the content. Decoding UTF-8-first
+ * with a per-byte cp1252 rescue preserves both:
+ *  - genuine multi-byte UTF-8 (e.g. '…' as E2 80 A6) is decoded correctly, and
+ *  - stray cp1252 bytes (e.g. '…' as the single byte 0x85, or smart quotes 0x91-0x94) are recovered
+ *    instead of being silently turned into the U+FFFD replacement character.
+ *
+ * Bytes that are already the UTF-8 encoding of U+FFFD (EF BF BD) in the source file were corrupted
+ * upstream, before this reader ever runs; they decode as valid UTF-8 and are preserved as-is (there
+ * is no information left to recover). (CSA-458)
+ */
+class Utf8WithCp1252FallbackReader(
+    input: InputStream,
+) : Reader() {
+    // Up to 3 look-ahead bytes may need to be pushed back when a multi-byte UTF-8 sequence turns
+    // out to be invalid partway through.
+    private val stream = PushbackInputStream(BufferedInputStream(input), 3)
+
+    // Holds decoded characters not yet handed back to the caller (e.g. the low surrogate of an
+    // astral code point, or overflow when the caller's buffer is full).
+    private val pending = ArrayDeque<Char>()
+
+    override fun read(
+        cbuf: CharArray,
+        off: Int,
+        len: Int,
+    ): Int {
+        if (len == 0) return 0
+        var count = 0
+        while (count < len) {
+            if (pending.isEmpty()) {
+                val decoded = decodeNext() ?: break
+                decoded.forEach { pending.addLast(it) }
+                if (pending.isEmpty()) break
+            }
+            cbuf[off + count] = pending.removeFirst()
+            count++
+        }
+        return if (count == 0) -1 else count
+    }
+
+    /** Decode the next logical character(s) from the stream, or null at end-of-stream. */
+    private fun decodeNext(): CharArray? {
+        val lead = stream.read()
+        if (lead == -1) return null
+        if (lead < 0x80) return charArrayOf(lead.toChar())
+
+        val seqLen =
+            when (lead) {
+                in 0xC2..0xDF -> 2
+                in 0xE0..0xEF -> 3
+                in 0xF0..0xF4 -> 4
+                else -> 0 // continuation byte or invalid lead -> not a valid UTF-8 start
+            }
+        if (seqLen == 0) return rescueCp1252(lead)
+
+        val bytes = ByteArray(seqLen)
+        bytes[0] = lead.toByte()
+        var read = 1
+        while (read < seqLen) {
+            val next = stream.read()
+            if (next == -1 || next !in 0x80..0xBF) {
+                // Not a valid continuation: push back everything after the lead byte (in order),
+                // then rescue the lead byte alone as cp1252.
+                if (next != -1) stream.unread(next)
+                for (j in read - 1 downTo 1) {
+                    stream.unread(bytes[j].toInt() and 0xFF)
+                }
+                return rescueCp1252(lead)
+            }
+            bytes[read] = next.toByte()
+            read++
+        }
+        return String(bytes, StandardCharsets.UTF_8).toCharArray()
+    }
+
+    /** Decode a single byte using cp1252 (undefined cp1252 bytes fall back to U+FFFD). */
+    private fun rescueCp1252(b: Int): CharArray = String(byteArrayOf(b.toByte()), WINDOWS_1252).toCharArray()
+
+    override fun close() = stream.close()
+
+    companion object {
+        private val WINDOWS_1252: Charset = Charset.forName("windows-1252")
+    }
+}

--- a/package-toolkit/runtime/src/test/kotlin/com/atlan/pkg/serde/csv/CSVEncodingTest.kt
+++ b/package-toolkit/runtime/src/test/kotlin/com/atlan/pkg/serde/csv/CSVEncodingTest.kt
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2026 Atlan Pte. Ltd. */
+package com.atlan.pkg.serde.csv
+
+import de.siegmar.fastcsv.reader.CsvReader
+import java.io.File
+import java.nio.charset.Charset
+import java.nio.charset.StandardCharsets
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies that non-UTF-8 (and mixed-encoding) input CSVs are decoded losslessly, rather than
+ * silently corrupting non-ASCII characters into the Unicode replacement character U+FFFD.
+ *
+ * The canonical failure: Excel's "Save As -> CSV" on Windows writes Windows-1252 (cp1252), where the
+ * ellipsis '…' (U+2026) is the single byte 0x85 -- an invalid UTF-8 lead byte that the default JDK
+ * decoder replaces with U+FFFD. Real customer files are frequently *mixed* (some cp1252 bytes, some
+ * genuine UTF-8), so the decoder must handle both within a single file. (CSA-458)
+ */
+class CSVEncodingTest {
+    private val ellipsis = '…' // …
+    private val leftQuote = '‘' // '
+    private val windows1252: Charset = Charset.forName("windows-1252")
+
+    private fun tempCsv(
+        bytes: ByteArray,
+    ): File =
+        File.createTempFile("aim-encoding", ".csv").apply {
+            outputStream().use { it.write(bytes) }
+        }
+
+    private fun tempCsv(
+        content: String,
+        charset: Charset,
+        bom: ByteArray = ByteArray(0),
+    ): File = tempCsv(bom + content.toByteArray(charset))
+
+    /** Read the last field of the single data row, using the code path production uses. */
+    private fun readLastField(file: File): String {
+        CsvReader.builder().ofCsvRecord(CSVEncoding.open(file.toPath())).use { reader ->
+            val rows = reader.stream().toList()
+            val data = rows[1]
+            return data.getField(data.fieldCount - 1)
+        }
+    }
+
+    private fun row(description: String) = "typeName,qualifiedName,description\nTable,default/x/db/sch/t,\"$description\"\n"
+
+    @Test
+    fun windows1252EllipsisIsPreservedNotCorrupted() {
+        val file = tempCsv(row("ends with $ellipsis"), windows1252)
+        val value = readLastField(file)
+        assertTrue(value.contains(ellipsis), "Expected the ellipsis to be preserved, got: [$value]")
+        assertFalse(value.contains('�'), "Value was corrupted with U+FFFD: [$value]")
+    }
+
+    @Test
+    fun windows1252SmartQuotesArePreserved() {
+        val file = tempCsv(row("a $leftQuote quoted $leftQuote value"), windows1252)
+        val value = readLastField(file)
+        assertTrue(value.contains(leftQuote), "Expected smart quote to be preserved, got: [$value]")
+        assertFalse(value.contains('�'), "Value was corrupted with U+FFFD: [$value]")
+    }
+
+    @Test
+    fun utf8EllipsisIsPreserved() {
+        val file = tempCsv(row("ends with $ellipsis"), StandardCharsets.UTF_8)
+        val value = readLastField(file)
+        assertTrue(value.contains(ellipsis), "Expected the ellipsis to be preserved, got: [$value]")
+        assertFalse(value.contains('�'), "Value was corrupted with U+FFFD: [$value]")
+    }
+
+    @Test
+    fun utf8BomIsStrippedAndContentPreserved() {
+        val file = tempCsv(row("ends with $ellipsis"), StandardCharsets.UTF_8, bom = byteArrayOf(0xEF.toByte(), 0xBB.toByte(), 0xBF.toByte()))
+        // header column must still resolve cleanly (BOM must not leak into the first field)
+        assertEquals(listOf("typeName", "qualifiedName", "description"), CSVXformer.getHeader(file.absolutePath))
+        val value = readLastField(file)
+        assertTrue(value.contains(ellipsis), "Expected the ellipsis to be preserved, got: [$value]")
+    }
+
+    /**
+     * The real VS customer file mixes a genuine UTF-8 ellipsis (E2 80 A6) with a cp1252 ellipsis
+     * (0x85) in the same field. A single whole-file charset choice mangles one or the other; the
+     * hybrid decoder must recover both.
+     */
+    @Test
+    fun mixedUtf8AndCp1252InSameFieldAreBothRecovered() {
+        val prefix = "typeName,qualifiedName,description\nTable,default/x/db/sch/t,\"utf8=".toByteArray(StandardCharsets.UTF_8)
+        val mid = " cp1252=".toByteArray(StandardCharsets.US_ASCII)
+        val suffix = "\"\n".toByteArray(StandardCharsets.US_ASCII)
+        val bytes = prefix + byteArrayOf(0xE2.toByte(), 0x80.toByte(), 0xA6.toByte()) + mid + byteArrayOf(0x85.toByte()) + suffix
+        val file = tempCsv(bytes)
+        val value = readLastField(file)
+        assertEquals(2, value.count { it == ellipsis }, "Both the UTF-8 and cp1252 ellipses should be recovered: [$value]")
+        assertFalse(value.contains('�'), "Value was corrupted with U+FFFD: [$value]")
+        assertFalse(value.contains("â€¦"), "Genuine UTF-8 ellipsis was mangled by a cp1252 decode: [$value]")
+    }
+
+    /** A 4-byte (astral) UTF-8 code point must survive intact (surrogate pair handling). */
+    @Test
+    fun astralUtf8CodePointIsPreserved() {
+        val emoji = "😀" // U+1F600 grinning face
+        val file = tempCsv(row("emoji $emoji here"), StandardCharsets.UTF_8)
+        val value = readLastField(file)
+        assertTrue(value.contains(emoji), "Expected the astral code point to be preserved, got: [$value]")
+        assertFalse(value.contains('�'), "Value was corrupted with U+FFFD: [$value]")
+    }
+}

--- a/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/Utf8EncodingImportTest.kt
+++ b/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/Utf8EncodingImportTest.kt
@@ -1,0 +1,77 @@
+/* SPDX-License-Identifier: Apache-2.0
+   Copyright 2026 Atlan Pte. Ltd. */
+package com.atlan.pkg.aim
+
+import AssetImportCfg
+import com.atlan.model.assets.Glossary
+import com.atlan.model.fields.AtlanField
+import com.atlan.pkg.PackageTest
+import com.atlan.pkg.Utils
+import java.nio.charset.Charset
+import java.nio.file.Paths
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+/**
+ * End-to-end proof for CSA-458: importing a CSV that is encoded as Windows-1252 (as Excel's
+ * "Save As -> CSV" produces on Windows) must round-trip typographic Unicode characters intact,
+ * rather than storing them as the replacement character U+FFFD.
+ *
+ * This runs the full path against a live tenant: cp1252 CSV -> decode -> asset write -> Atlas
+ * storage -> read-back -> assertion.
+ */
+class Utf8EncodingImportTest : PackageTest("utf8") {
+    override val logger = Utils.getLogger(this.javaClass.name)
+
+    private val glossaryName = makeUnique("g")
+    private val testFile = "cp1252_input.csv"
+
+    // '…' U+2026, '‘'/'’' U+2018/U+2019, '—' U+2014, 'é' U+00E9 -- all representable in cp1252.
+    private val description = "Ends with an ellipsis … and ‘smart quotes’ — plus café"
+
+    private val header =
+        "qualifiedName,typeName,name,anchor,parentCategory,categories,displayName,description,userDescription," +
+            "ownerUsers,ownerGroups,certificateStatus,certificateStatusMessage,announcementType,announcementTitle," +
+            "announcementMessage,atlanTags,links,readme,starredDetails,seeAlso,preferredTerms,synonyms,antonyms," +
+            "translatedTerms,validValuesFor,classifies"
+
+    private val glossaryAttrs: List<AtlanField> = listOf(Glossary.NAME, Glossary.USER_DESCRIPTION)
+
+    private fun prepFile() {
+        val row = ",AtlasGlossary,$glossaryName,,,,,,\"$description\",,,,,,,,,,,,,,,,,,"
+        val content = "$header\n$row\n"
+        // Write the CSV as Windows-1252 bytes, exactly as an Excel-on-Windows "Save As CSV" would.
+        val output = Paths.get(testDirectory, testFile).toFile()
+        output.writeBytes(content.toByteArray(Charset.forName("windows-1252")))
+    }
+
+    override fun setup() {
+        prepFile()
+        runCustomPackage(
+            AssetImportCfg(
+                glossariesFile = Paths.get(testDirectory, testFile).toString(),
+                glossariesUpsertSemantic = "upsert",
+                glossariesFailOnErrors = true,
+            ),
+            Importer::main,
+        )
+    }
+
+    override fun teardown() {
+        removeGlossary(glossaryName)
+    }
+
+    @Test(groups = ["aim.utf8.create"])
+    fun descriptionRoundTripsWithoutCorruption() {
+        val glossary = Glossary.findByName(client, glossaryName, glossaryAttrs)
+        assertNotNull(glossary)
+        assertEquals(glossaryName, glossary.name)
+        assertNotNull(glossary.userDescription)
+        assertFalse(glossary.userDescription.contains('�'), "Description was corrupted with U+FFFD: [${glossary.userDescription}]")
+        assertTrue(glossary.userDescription.contains('…'), "Ellipsis was lost: [${glossary.userDescription}]")
+        assertEquals(description, glossary.userDescription)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes [CSA-458](https://linear.app/atlan-epd/issue/CSA-458) — Asset Import corrupts Unicode characters (e.g. `…` U+2026 → `�` U+FFFD).

Asset Import read input CSVs assuming UTF-8 via FastCSV's `Path` overload, which relies on the JDK's default decoder behaviour of **silently replacing** any byte that isn't valid UTF-8 with the replacement character `U+FFFD`. Files produced by Excel's "Save As → CSV" on Windows are **Windows-1252 (cp1252)**, so typographic characters were corrupted on import — e.g. the ellipsis `…` (byte `0x85` in cp1252) became `U+FFFD`, rendering as a broken glyph in the UI and re-exporting as `ï¿½`. The row still imported "successfully" with the corrupted value, so this was a silent data-integrity bug.

## Root cause

The corruption is at the CSV read boundary (`CSVReader`, `CSVXformer`), not in Atlas or the UI. Confirmed by byte-level inspection of the reported customer file, which is **mixed-encoding** (mostly cp1252, some genuine UTF-8, plus some cells already corrupted before upload).

## Fix

Input is now decoded **UTF-8-first with a per-byte Windows-1252 fallback**, and BOM-aware for UTF-16/32:

- `CSVEncoding` — opens a CSV as a `Reader` (BOM-aware, else hybrid decoder)
- `Utf8WithCp1252FallbackReader` — streaming UTF-8-first decoder; any byte that isn't valid UTF-8 is rescued via cp1252 (handles surrogate pairs and pushback on partial sequences)
- `CSVReader` / `CSVXformer` — read via `CSVEncoding.open(...)`

This correctly handles clean UTF-8, clean cp1252, and mixed files within a single field, without needing to enumerate encodings. Output remains UTF-8. See the [Linear thread](https://linear.app/atlan-epd/issue/CSA-458) for the discussion on why cp1252 is the deliberate single fallback and why full charset auto-detection was not chosen.

## Verification

- **Unit tests** (`CSVEncodingTest`): cp1252, mixed UTF-8/cp1252 in one field, UTF-8 BOM, and astral (4-byte) code points.
- **Real customer file** (6,464 rows), through the shipped code path: all 16 ellipses recovered, **0** new `U+FFFD` and **0** mojibake introduced. (The only remaining 16 `U+FFFD` were already corrupted in the file before upload and are unrecoverable.)
- **Live end-to-end on fs3** (`Utf8EncodingImportTest`): imports a cp1252 CSV → creates a glossary → reads it back from the tenant → asserts the description is byte-perfect (`…`, smart quotes, em-dash, `é`), no `U+FFFD`.

## Notes

- A follow-up docs update will state UTF-8 as the officially supported input encoding (the cp1252 fallback is best-effort graceful degradation for the common Excel-on-Windows case).


[CSA-458]: https://atlanhq.atlassian.net/browse/CSA-458?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ