### PR TITLE
test(aim): fix connection qualifiedName collision in TagExtraAttributesTest

### DIFF
--- a/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/TagExtraAttributesTest.kt
+++ b/samples/packages/asset-import/src/test/kotlin/com/atlan/pkg/aim/TagExtraAttributesTest.kt
@@ -25,7 +25,13 @@ class TagExtraAttributesTest : PackageTest("tea") {
     override val logger = Utils.getLogger(this.javaClass.name)
 
     private val c1 = makeUnique("c1")
-    private val c1Type = AtlanConnectorType.BIGID
+
+    // Must be a connector type not used by any other test: connection qualifiedNames are
+    // "default/{connector}/{epoch-seconds}", and Connection.generateQualifiedName() only guarantees
+    // uniqueness within a single JVM. When tests run in parallel across processes (as in CI), two
+    // connections of the same connector type created in the same second collide on qualifiedName,
+    // turning this create into an unauthorized update (403). TagManagementTest already uses BIGID.
+    private val c1Type = AtlanConnectorType.SALESFORCE
     private val t1 = makeUnique("t1")
 
     private lateinit var connection: Connection


### PR DESCRIPTION
## Problem

`TagExtraAttributesTest.testsSetup` fails intermittently in CI (e.g. release-7.3.1 run 29243874471, 6/7 attempts) at connection creation:

```
403 ATLAS-403-00-001: ...apikey... is not authorized to perform update entity: type=Connection
   at Connection.save(Connection.java:714)   ← the POST /entity/bulk create
   at TagExtraAttributesTest.createConnection(TagExtraAttributesTest.kt)
```

## Root cause

Connection qualifiedNames are `default/{connector}/{epoch-seconds}`, and `Connection.generateQualifiedName()` only guarantees uniqueness **within a single JVM** (`synchronized` + a 1s sleep). When tests run in parallel across processes (as in CI), two connections of the **same connector type** created in the same wall-clock second get an **identical qualifiedName**. `POST /entity/bulk` then matches the existing entity and authorizes the write as an *update* (hence the "update entity" wording) → 403, because the caller isn't yet an admin of the colliding connection. Teardown's `findByName` looks up by the unique *name*, so it finds nothing → the cascading `NotFoundException` seen in the logs.

`TagManagementTest` and `TagExtraAttributesTest` were the **only two tests using `BIGID`**, so they collided with each other.

## Fix

Switch `TagExtraAttributesTest` to `SALESFORCE` — a SAAS connector (same category as BigID) used by **no other test** — so the two tests' qualifiedNames can never share a connector prefix. `SourceTag` is a generic asset type here, so the connector type only changes the QN prefix; the test's assertions are unaffected.

## Note / follow-up

The deeper root cause is in the SDK: `generateQualifiedName` is not safe across processes. A proper follow-up would make it process-unique (e.g. higher-resolution timestamp + random suffix) so no two connection tests can ever collide. This PR is the targeted test-side fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)