### PR TITLE
test: harden flaky/broken release integration tests (TableSearch, SQLAsset, Suggestions)

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/AtlanLiveTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/AtlanLiveTest.java
@@ -239,6 +239,41 @@ public abstract class AtlanLiveTest {
         return response;
     }
 
+    /** Fetch-and-assert block used by {@link #retryUntilAsserted(RetryableAssertion)}. */
+    @FunctionalInterface
+    protected interface RetryableAssertion<T> {
+        T get() throws AtlanException;
+    }
+
+    /**
+     * Retry an assertion block until it passes, or the retry limit is hit (in which case the last
+     * {@link AssertionError} is rethrown). Use this for state that is confirmed asynchronously --
+     * e.g. audit indexing or owner-group propagation -- where asserting on the immediate/synchronous
+     * response is racy. The block should fetch fresh state and perform its own assertions, throwing
+     * {@link AssertionError} while the expected end-state has not yet materialized; the value from
+     * the first fully-passing invocation is returned.
+     *
+     * @param assertion block that fetches state and asserts on it, returning a value on success
+     * @return the value from the first invocation whose assertions all pass
+     * @throws AtlanException on any API communication issues
+     * @throws InterruptedException if the busy-wait loop for retries is interrupted
+     */
+    protected <T> T retryUntilAsserted(RetryableAssertion<T> assertion) throws AtlanException, InterruptedException {
+        int count = 0;
+        int maxRetries = client.getMaxNetworkRetries();
+        while (true) {
+            try {
+                return assertion.get();
+            } catch (AssertionError e) {
+                if (count >= maxRetries) {
+                    throw e;
+                }
+                Thread.sleep(HttpClient.waitLongTime(count).toMillis());
+                count++;
+            }
+        }
+    }
+
     /**
      * Since search is eventually consistent, retry it until we arrive at the number of results
      * we expect (or hit the retry limit).

--- a/integration-tests/src/test/java/com/atlan/java/sdk/SQLAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/SQLAssetTest.java
@@ -1419,20 +1419,17 @@ public class SQLAssetTest extends AtlanLiveTest {
             dependsOnGroups = {"asset.update.column.removeTerms"})
     void searchAuditLogByGuid() throws AtlanException, InterruptedException {
         waitForTagsToSync(taggedAssetGuids, log);
-        AuditSearchRequest request =
-                AuditSearchRequest.byGuid(client, column5.getGuid(), 50).build();
-
-        // We expect at least 32 meaningful audits (may include spurious no-op audits)
-        AuditSearchResponse response = retrySearchUntil(request, 32L);
-
-        validateAudits(response.getEntityAudits());
-
-        AuditSearch.AuditSearchBuilder<?, ?> builder = AuditSearch.builder(client)
-                .where(AuditSearchRequest.ENTITY_ID.eq(column5.getGuid()))
-                .sort(AuditSearchRequest.CREATED.order(SortOrder.Desc))
-                .pageSize(10);
-        assertTrue(builder.count() >= 32, "Expected at least 32 audits, but found " + builder.count());
-        validateAudits(builder.stream().collect(Collectors.toList()));
+        // Audit indexing is eventually consistent, and the stream contains spurious no-op audits, so
+        // a raw count threshold can be satisfied before the terminal audit is indexed. Retry the whole
+        // fetch-and-validate until the expected end-state is actually present, rather than gating on a
+        // count and validating a possibly-incomplete snapshot.
+        retryUntilAsserted(() -> {
+            AuditSearchResponse response = AuditSearchRequest.byGuid(client, column5.getGuid(), 50)
+                    .build()
+                    .search(client);
+            validateAudits(response.getEntityAudits());
+            return response;
+        });
     }
 
     @Test(
@@ -1440,12 +1437,15 @@ public class SQLAssetTest extends AtlanLiveTest {
             dependsOnGroups = {"asset.update.column.removeTerms"})
     void searchAuditLogByQN() throws AtlanException, InterruptedException {
         waitForTagsToSync(taggedAssetGuids, log);
-        AuditSearchRequest request = AuditSearchRequest.byQualifiedName(
-                        client, Column.TYPE_NAME, column5.getQualifiedName(), 50)
-                .build();
-        // We expect at least 32 meaningful audits (may include spurious no-op audits)
-        AuditSearchResponse response = retrySearchUntil(request, 32L);
-        validateAudits(response.getEntityAudits());
+        // As above: gate on the expected end-state, not a spurious-inflated count.
+        retryUntilAsserted(() -> {
+            AuditSearchResponse response = AuditSearchRequest.byQualifiedName(
+                            client, Column.TYPE_NAME, column5.getQualifiedName(), 50)
+                    .build()
+                    .search(client);
+            validateAudits(response.getEntityAudits());
+            return response;
+        });
     }
 
     /**

--- a/integration-tests/src/test/java/com/atlan/java/sdk/SuggestionsTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/SuggestionsTest.java
@@ -264,7 +264,7 @@ public class SuggestionsTest extends AtlanLiveTest {
                 "suggestions.create.group.owners",
                 "suggestions.create.atlantags"
             })
-    void updateT1() throws AtlanException {
+    void updateT1() throws AtlanException, InterruptedException {
         Table toUpdate = Table.updater(table1.getQualifiedName(), TABLE_NAME)
                 .ownerGroup(ownerGroup.getName())
                 .description(SYSTEM_DESCRIPTION)
@@ -283,11 +283,14 @@ public class SuggestionsTest extends AtlanLiveTest {
         assertEquals(
                 response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet()),
                 Set.of(Table.TYPE_NAME, GlossaryTerm.TYPE_NAME));
-        Table result = response.getResult(toUpdate);
-        assertNotNull(result);
-        assertNotNull(result.getOwnerGroups());
-        assertEquals(result.getOwnerGroups().size(), 1);
-        assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
+        // Owner-group validation on the asset service lags group creation, so the synchronous save
+        // response can omit the just-assigned group. Assert on a retried read-back instead.
+        retryUntilAsserted(() -> {
+            Table result = Table.get(client, table1.getGuid(), false);
+            assertNotNull(result.getOwnerGroups());
+            assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
+            return result;
+        });
     }
 
     @Test(
@@ -297,7 +300,7 @@ public class SuggestionsTest extends AtlanLiveTest {
                 "suggestions.create.group.owners",
                 "suggestions.create.atlantags"
             })
-    void updateT3() throws AtlanException {
+    void updateT3() throws AtlanException, InterruptedException {
         Table toUpdate = Table.updater(table3.getQualifiedName(), VIEW_NAME)
                 .ownerGroup(ownerGroup.getName())
                 .description(SYSTEM_DESCRIPTION)
@@ -316,11 +319,13 @@ public class SuggestionsTest extends AtlanLiveTest {
         assertEquals(
                 response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet()),
                 Set.of(Table.TYPE_NAME, GlossaryTerm.TYPE_NAME));
-        Table result = response.getResult(toUpdate);
-        assertNotNull(result);
-        assertNotNull(result.getOwnerGroups());
-        assertEquals(result.getOwnerGroups().size(), 1);
-        assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
+        // See updateT1: owner-group propagation lags, so assert on a retried read-back.
+        retryUntilAsserted(() -> {
+            Table result = Table.get(client, table3.getGuid(), false);
+            assertNotNull(result.getOwnerGroups());
+            assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
+            return result;
+        });
     }
 
     @Test(
@@ -330,7 +335,7 @@ public class SuggestionsTest extends AtlanLiveTest {
                 "suggestions.create.group.owners",
                 "suggestions.create.atlantags"
             })
-    void updateT1C1() throws AtlanException {
+    void updateT1C1() throws AtlanException, InterruptedException {
         Column toUpdate = Column.updater(t1c1.getQualifiedName(), COLUMN_NAME1)
                 .ownerGroup(ownerGroup.getName())
                 .description(SYSTEM_DESCRIPTION)
@@ -349,11 +354,13 @@ public class SuggestionsTest extends AtlanLiveTest {
         assertEquals(
                 response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet()),
                 Set.of(Column.TYPE_NAME, GlossaryTerm.TYPE_NAME));
-        Column result = response.getResult(toUpdate);
-        assertNotNull(result);
-        assertNotNull(result.getOwnerGroups());
-        assertEquals(result.getOwnerGroups().size(), 1);
-        assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
+        // See updateT1: owner-group propagation lags, so assert on a retried read-back.
+        retryUntilAsserted(() -> {
+            Column result = Column.get(client, t1c1.getGuid(), false);
+            assertNotNull(result.getOwnerGroups());
+            assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
+            return result;
+        });
     }
 
     @Test(
@@ -363,7 +370,7 @@ public class SuggestionsTest extends AtlanLiveTest {
                 "suggestions.create.group.owners",
                 "suggestions.create.atlantags"
             })
-    void updateV1C1() throws AtlanException {
+    void updateV1C1() throws AtlanException, InterruptedException {
         Column toUpdate = Column.updater(v1c1.getQualifiedName(), COLUMN_NAME1)
                 .ownerGroup(ownerGroup.getName())
                 .description(SYSTEM_DESCRIPTION)
@@ -378,11 +385,13 @@ public class SuggestionsTest extends AtlanLiveTest {
         assertEquals(
                 response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet()),
                 Set.of(Column.TYPE_NAME, GlossaryTerm.TYPE_NAME));
-        Column result = response.getResult(toUpdate);
-        assertNotNull(result);
-        assertNotNull(result.getOwnerGroups());
-        assertEquals(result.getOwnerGroups().size(), 1);
-        assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
+        // See updateT1: owner-group propagation lags, so assert on a retried read-back.
+        retryUntilAsserted(() -> {
+            Column result = Column.get(client, v1c1.getGuid(), false);
+            assertNotNull(result.getOwnerGroups());
+            assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
+            return result;
+        });
     }
 
     @Test(

--- a/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java
@@ -32,10 +32,13 @@ public class TableSearchTest extends AtlanLiveTest {
     private Schema schema = null;
     private static final String PREFIX = makeUnique("TABLE_ATTR");
     private static final String name = PREFIX + "_name";
-    private static final Set<String> ownerUsers = Set.of("user1", "user2");
-    private static final Set<String> ownerGroups = Set.of("group1", "group2");
     private static final String GROUP_NAME1 = PREFIX + "1";
     private static final String GROUP_NAME2 = PREFIX + "2";
+    // Owners must reference principals that actually exist in the tenant: the backend validates
+    // owner users/groups on write and silently drops unknown ones, so hard-coded placeholder names
+    // would never round-trip. Use the fixed test user and the two groups this test creates below.
+    private static final Set<String> ownerUsers = Set.of(FIXED_USER);
+    private static final Set<String> ownerGroups = Set.of(GROUP_NAME1, GROUP_NAME2);
     private Column column1 = null;
     private Column column2 = null;
     public static final String COLUMN_NAME1 = PREFIX + "_col1";


### PR DESCRIPTION
Fixes three release-run integration-test failures (from run 29243874471) with distinct root causes, plus a shared retry helper. All are test-side changes — no SDK changes.

## 1. `TableSearchTest.searchCollectionTypes` — real bug (deterministic, failed 7/7 attempts)
Asserted owner users/groups against hard-coded `user1`/`user2`/`group1`/`group2` that don't exist in the tenant. The backend validates owners on write and **silently drops unknown ones**, so the round-trip assertion (`getOwnerUsers().containsAll(...)`) could never pass.

**Fix:** point owners at `FIXED_USER` and the two groups the test actually creates (`GROUP_NAME1`/`GROUP_NAME2`), and assert against those.

## 2. `SQLAssetTest.searchAuditLogByGuid` / `searchAuditLogByQN` — flaky (eventual consistency)
The retry gated on a raw audit **count** (`retrySearchUntil(request, 32L)`). The audit stream contains spurious no-op audits, so the count reaches 32 **before** the terminal "terms cleared" audit is indexed; validation then ran against an incomplete snapshot and the terminal assertion failed. A redundant, **un-retried** second query made it worse.

**Fix:** retry the whole fetch-and-validate until the expected end-state is present (semantic gate, not a count), and remove the redundant query. `searchAuditLogByQN` had the identical latent issue and is fixed too.

## 3. `SuggestionsTest.updateT1` / `updateT1C1` / `updateT3` / `updateV1C1` — flaky (propagation lag)
`AdminTest.createGroup` confirms the group only via the admin API, but the asset service's **owner-group validation cache lags**. Assigning the freshly-created group immediately, then asserting on the **synchronous save response**, intermittently saw the owner group silently dropped (`expected [1] but found [0]`). (Collision across parallel jobs was checked and ruled out — the group name is per-JVM unique and only this test uses it.)

**Fix:** assert on a **retried read-back** of the asset (`Table.get`/`Column.get`) until the owner group materializes. `updateT3`/`updateV1C1` shared the same latent bug and are fixed too.

## Shared helper
Adds `AtlanLiveTest.retryUntilAsserted(...)` — retries an assertion block on `AssertionError` with `waitLongTime` backoff — so these tests converge on eventual state instead of trusting a count or an immediate response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)