### PR TITLE
test: re-apply owner groups until persisted (fix owner-group write-time drop)

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/SuggestionsTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/SuggestionsTest.java
@@ -283,11 +283,16 @@ public class SuggestionsTest extends AtlanLiveTest {
         assertEquals(
                 response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet()),
                 Set.of(Table.TYPE_NAME, GlossaryTerm.TYPE_NAME));
-        // Owner-group validation on the asset service lags group creation, so the synchronous save
-        // response can omit the just-assigned group. Assert on a retried read-back instead.
+        // The owner-group validation cache on the asset service lags group creation, so the initial
+        // assignment can be silently dropped (the group is never stored, so a read-back alone can
+        // never recover it). Re-apply the owner group until it persists: a fresh write re-validates
+        // and succeeds once the group has propagated.
         retryUntilAsserted(() -> {
+            Table.updater(table1.getQualifiedName(), TABLE_NAME)
+                    .ownerGroup(ownerGroup.getName())
+                    .build()
+                    .save(client);
             Table result = Table.get(client, table1.getGuid(), false);
-            assertNotNull(result.getOwnerGroups());
             assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
             return result;
         });
@@ -319,10 +324,13 @@ public class SuggestionsTest extends AtlanLiveTest {
         assertEquals(
                 response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet()),
                 Set.of(Table.TYPE_NAME, GlossaryTerm.TYPE_NAME));
-        // See updateT1: owner-group propagation lags, so assert on a retried read-back.
+        // See updateT1: re-apply the owner group until it persists.
         retryUntilAsserted(() -> {
+            Table.updater(table3.getQualifiedName(), VIEW_NAME)
+                    .ownerGroup(ownerGroup.getName())
+                    .build()
+                    .save(client);
             Table result = Table.get(client, table3.getGuid(), false);
-            assertNotNull(result.getOwnerGroups());
             assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
             return result;
         });
@@ -354,10 +362,13 @@ public class SuggestionsTest extends AtlanLiveTest {
         assertEquals(
                 response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet()),
                 Set.of(Column.TYPE_NAME, GlossaryTerm.TYPE_NAME));
-        // See updateT1: owner-group propagation lags, so assert on a retried read-back.
+        // See updateT1: re-apply the owner group until it persists.
         retryUntilAsserted(() -> {
+            Column.updater(t1c1.getQualifiedName(), COLUMN_NAME1)
+                    .ownerGroup(ownerGroup.getName())
+                    .build()
+                    .save(client);
             Column result = Column.get(client, t1c1.getGuid(), false);
-            assertNotNull(result.getOwnerGroups());
             assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
             return result;
         });
@@ -385,10 +396,13 @@ public class SuggestionsTest extends AtlanLiveTest {
         assertEquals(
                 response.getUpdatedAssets().stream().map(Asset::getTypeName).collect(Collectors.toSet()),
                 Set.of(Column.TYPE_NAME, GlossaryTerm.TYPE_NAME));
-        // See updateT1: owner-group propagation lags, so assert on a retried read-back.
+        // See updateT1: re-apply the owner group until it persists.
         retryUntilAsserted(() -> {
+            Column.updater(v1c1.getQualifiedName(), COLUMN_NAME1)
+                    .ownerGroup(ownerGroup.getName())
+                    .build()
+                    .save(client);
             Column result = Column.get(client, v1c1.getGuid(), false);
-            assertNotNull(result.getOwnerGroups());
             assertEquals(result.getOwnerGroups(), Set.of(ownerGroup.getName()));
             return result;
         });

--- a/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java
@@ -141,6 +141,18 @@ public class TableSearchTest extends AtlanLiveTest {
         assertNotNull(table.getQualifiedName());
         assertEquals(table.getName(), name);
         assertEquals(table.getSchemaQualifiedName(), schema.getQualifiedName());
+        // ownerGroups reference just-created groups, whose owner-group validation lags creation on
+        // the asset service; the initial write can silently drop them (never stored). Re-apply until
+        // they persist, so the search assertions below have something to find.
+        retryUntilAsserted(() -> {
+            Table.updater(table.getQualifiedName(), name)
+                    .ownerGroups(ownerGroups)
+                    .build()
+                    .save(client);
+            Table refreshed = Table.get(client, table.getGuid(), false);
+            assertTrue(refreshed.getOwnerGroups().containsAll(ownerGroups));
+            return refreshed;
+        });
     }
 
     @Test(
@@ -193,23 +205,27 @@ public class TableSearchTest extends AtlanLiveTest {
     @Test(
             groups = {"table.search.collections"},
             dependsOnGroups = {"t" + "able.search.consistent"})
-    void searchCollectionTypes() throws AtlanException {
+    void searchCollectionTypes() throws AtlanException, InterruptedException {
         Set<AtlanField> fields = Set.of(Table.OWNER_USERS, Table.OWNER_GROUPS, Connection.QUERY_PREVIEW_CONFIG);
         IndexSearchRequest request = Table.select(client)
                 .where(Table.QUALIFIED_NAME.eq(table.getQualifiedName()))
                 .includesOnResults(fields)
                 .toRequest();
-        IndexSearchResponse response = request.search(client);
-        assertNotNull(response);
-        assertEquals(response.getApproximateCount(), 1L);
-        List<Asset> results = response.getAssets();
-        assertEquals(results.size(), 1);
-        Table found = (Table) results.get(0);
-        assertTrue(found.getOwnerUsers().containsAll(ownerUsers));
-        assertTrue(found.getOwnerGroups().containsAll(ownerGroups));
+        // Retry until the (re-applied) owner collections have been indexed, tolerating search lag.
+        retryUntilAsserted(() -> {
+            IndexSearchResponse response = request.search(client);
+            assertNotNull(response);
+            assertEquals(response.getApproximateCount(), 1L);
+            List<Asset> results = response.getAssets();
+            assertEquals(results.size(), 1);
+            Table found = (Table) results.get(0);
+            assertTrue(found.getOwnerUsers().containsAll(ownerUsers));
+            assertTrue(found.getOwnerGroups().containsAll(ownerGroups));
 
-        assertEquals(found.getQueryPreviewConfig().get("key1"), "value1");
-        assertEquals(found.getQueryPreviewConfig().get("key2"), "value2");
+            assertEquals(found.getQueryPreviewConfig().get("key1"), "value1");
+            assertEquals(found.getQueryPreviewConfig().get("key2"), "value2");
+            return response;
+        });
     }
 
     @Test(


### PR DESCRIPTION
Follow-up to #2640. That PR's owner-group fixes were **insufficient** — confirmed by CI run [29492686709](https://github.com/atlanhq/atlan-java/actions/runs/29492686709) (which included #2640 + #2639):

- ✅ asset-import (#2639) and `SQLAssetTest` passed.
- ❌ `TableSearchTest.searchCollectionTypes` — `ownerUsers` now passes (`FIXED_USER` pre-exists), but **`ownerGroups` still fails**.
- ❌ `SuggestionsTest.updateT1` — failed **inside the retried read-back** after ~3 minutes (`expected [jsdk_trident_…] but got []`).

## Corrected root cause
The ~3-minute read retry returning `[]` proves the owner group is dropped at **write** time (never stored), not lagging in the read/index. The freshly-created group hasn't propagated to the asset service's **owner-group validation cache** when the assignment is written, so it's silently discarded. #2640 retried the *read*, which can never recover a value that was never written. (Owner *users* are unaffected — `FIXED_USER` already exists, so its assignment is never dropped.)

## Fix
Re-apply the owner group via a **fresh write, retried until a direct read confirms it persisted** — once the group propagates, a subsequent write validates and sticks. Applied to:
- `SuggestionsTest` — `updateT1` / `updateT1C1` / `updateT3` / `updateV1C1`
- `TableSearchTest.createTable` (persist via direct GET) + `searchCollectionTypes` (retry the search to tolerate index lag on the re-applied groups)

Reuses the `retryUntilAsserted(...)` helper added in #2640.

🤖 Generated with [Claude Code](https://claude.com/claude-code)