### PR TITLE
test: assert owner groups by canonical name in TableSearchTest

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/TableSearchTest.java
@@ -38,7 +38,10 @@ public class TableSearchTest extends AtlanLiveTest {
     // owner users/groups on write and silently drops unknown ones, so hard-coded placeholder names
     // would never round-trip. Use the fixed test user and the two groups this test creates below.
     private static final Set<String> ownerUsers = Set.of(FIXED_USER);
-    private static final Set<String> ownerGroups = Set.of(GROUP_NAME1, GROUP_NAME2);
+    // Owner groups are keyed by each group's internal (slugified) name, which AtlanGroup.creator()
+    // derives from the alias (lowercased) -- NOT the alias string passed in. Populated from the
+    // created groups' canonical names in createTable().
+    private static Set<String> ownerGroups;
     private Column column1 = null;
     private Column column2 = null;
     public static final String COLUMN_NAME1 = PREFIX + "_col1";
@@ -60,6 +63,9 @@ public class TableSearchTest extends AtlanLiveTest {
         schema = SQLAssetTest.createSchema(client, SCHEMA_NAME, database);
         group1 = AdminTest.createGroup(client, GROUP_NAME1);
         group2 = AdminTest.createGroup(client, GROUP_NAME2);
+        // Use the groups' canonical (internal) names -- what owner-group storage keys on and what
+        // getOwnerGroups() returns -- not the aliases passed to createGroup.
+        ownerGroups = Set.of(group1.getName(), group2.getName());
         table = Table._internal()
                 .guid("-" + ThreadLocalRandom.current().nextLong(0, Long.MAX_VALUE - 1))
                 .name(name)


### PR DESCRIPTION
Follow-up to #2642. `TableSearchTest.searchCollectionTypes` still failed in run [29502177510](https://github.com/atlanhq/atlan-java/actions/runs/29502177510) — but for a reason distinct from the metastore race:

`AtlanGroup.creator(alias)` stores a group under an **internal, slugified name** (`generateName(alias)` = `alias.toLowerCase(...)`), separate from the alias. Owner groups are keyed by that internal name, and `getOwnerGroups()` returns it. The test referenced owner groups by `GROUP_NAME1`/`GROUP_NAME2` — the **mixed-case aliases** passed to `createGroup` — so `containsAll(...)` never matched and failed **deterministically** (the #2642 write-retry simply exhausted its budget over ~3.5 min).

`SuggestionsTest` passed in that same run because it already asserts against `ownerGroup.getName()` (the canonical name).

**Fix:** populate `ownerGroups` from `group1.getName()`/`group2.getName()` at runtime (once the groups are created in `createTable`), for both the assignment and the assertion. Owner users were already correct (`FIXED_USER` exists in the tenant).

🤖 Generated with [Claude Code](https://claude.com/claude-code)