### PR TITLE
test(rab): gate column search on lagging decimal attributes

### DIFF
--- a/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CreateThenUpsertRABTest.kt
+++ b/samples/packages/relational-assets-builder/src/test/kotlin/com/atlan/pkg/rab/CreateThenUpsertRABTest.kt
@@ -510,7 +510,18 @@ class CreateThenUpsertRABTest : PackageTest("ctu") {
                     .where(Column.VIEW_NAME.eq("TEST_VIEW"))
                     .includesOnResults(columnAttrs)
                     .toRequest()
-            val response = retrySearchUntil(request, 2)
+            // COL4's decimal attributes (numericScale/precision/rawDataTypeDefinition) can lag the
+            // column itself appearing in results, so gate on them being indexed rather than on count
+            // alone -- otherwise the value assertions below can read null.
+            val response =
+                retrySearchUntil(request, 2) { resp ->
+                    val col4 =
+                        resp.assets
+                            .orEmpty()
+                            .filterIsInstance<Column>()
+                            .firstOrNull { it.name == "COL4" }
+                    col4?.numericScale != null && col4.precision != null && col4.rawDataTypeDefinition != null
+                }
             val found = response.assets
             assertEquals(2, found.size)
             val colNames = found.stream().map(Asset::getName).toList()


### PR DESCRIPTION
`CreateThenUpsertRABTest.columnsForView1Created` failed in run [29502177510](https://github.com/atlanhq/atlan-java/actions/runs/29502177510) (all 3 attempts) with `expected [5.0] but found [null]` for `COL4.numericScale`.

**Root cause (same anti-pattern as the SQLAssetTest audit flake):** `validateColumnsForView` used `retrySearchUntil(request, 2)`, which gates only on result **count**. The two view columns become searchable before COL4's decimal attributes (`numericScale`/`precision`/`rawDataTypeDefinition`) finish indexing, so under tenant load the value assertions read `null`.

**Fix:** use the existing `retrySearchUntil(..., condition)` predicate to also wait until COL4's decimal attributes are populated, instead of gating on count alone. No new helper needed — `PackageTest.retrySearchUntil` already supports this exact case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)