### PR TITLE
test: harden remaining eventual-consistency anti-patterns (proactive sweep)

### DIFF
--- a/integration-tests/src/test/java/com/atlan/java/sdk/CustomMetadataTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/CustomMetadataTest.java
@@ -918,21 +918,32 @@ public class CustomMetadataTest extends AtlanLiveTest {
             groups = {"cm.read.term.audit"},
             dependsOnGroups = {"cm.update.term.remove.cm"})
     void readTermAuditByGuid() throws AtlanException, InterruptedException {
-        AuditSearchRequest request =
-                AuditSearchRequest.byGuid(client, term.getGuid(), 100).build();
-        AuditSearchResponse response = retrySearchUntil(request, 14L);
-        validateAudits(response.getEntityAudits());
+        // Audit indexing is eventually consistent and the stream includes spurious no-op audits, so a
+        // raw count gate can pass before the terminal custom-metadata audits land. Retry the whole
+        // fetch-and-validate until the expected sequence is present, rather than gating on a count.
+        // (Same fix as SQLAssetTest.searchAuditLogByGuid.)
+        retryUntilAsserted(() -> {
+            AuditSearchResponse response = AuditSearchRequest.byGuid(client, term.getGuid(), 100)
+                    .build()
+                    .search(client);
+            validateAudits(response.getEntityAudits());
+            return response;
+        });
     }
 
     @Test(
             groups = {"cm.read.term.audit"},
             dependsOnGroups = {"cm.update.term.remove.cm"})
     void readTermAuditByQN() throws AtlanException, InterruptedException {
-        AuditSearchRequest request = AuditSearchRequest.byQualifiedName(
-                        client, GlossaryTerm.TYPE_NAME, term.getQualifiedName(), 100)
-                .build();
-        AuditSearchResponse response = retrySearchUntil(request, 14L);
-        validateAudits(response.getEntityAudits());
+        // As above: gate on the expected end-state, not a spurious-inflated count.
+        retryUntilAsserted(() -> {
+            AuditSearchResponse response = AuditSearchRequest.byQualifiedName(
+                            client, GlossaryTerm.TYPE_NAME, term.getQualifiedName(), 100)
+                    .build()
+                    .search(client);
+            validateAudits(response.getEntityAudits());
+            return response;
+        });
     }
 
     @Test(

--- a/integration-tests/src/test/java/com/atlan/java/sdk/SQLAssetTest.java
+++ b/integration-tests/src/test/java/com/atlan/java/sdk/SQLAssetTest.java
@@ -898,19 +898,29 @@ public class SQLAssetTest extends AtlanLiveTest {
     @Test(
             groups = {"asset.update.column.owners"},
             dependsOnGroups = {"asset.read.column.5", "asset.create.group.owners"})
-    void updateColumnOwners() throws AtlanException {
+    void updateColumnOwners() throws AtlanException, InterruptedException {
         Column toUpdate = Column.updater(column5.getQualifiedName(), COLUMN_NAME5)
                 .ownerGroup(ownerGroup.getName())
                 .build();
         AssetMutationResponse response = toUpdate.save(client);
         Asset one = validateSingleUpdate(response);
         assertTrue(one instanceof Column);
-        Column updated = (Column) one;
-        validateUpdatedColumn(updated);
-        Set<String> groups = updated.getOwnerGroups();
-        assertNotNull(groups);
-        assertEquals(groups.size(), 1);
-        assertTrue(groups.contains(ownerGroup.getName()));
+        validateUpdatedColumn((Column) one);
+        // Owner-group validation lags group creation (MS-2016), so the assignment can be silently
+        // dropped off the synchronous response; re-apply until a read-back confirms it persisted
+        // (this also ensures the "ownerGroups set" audit exists for the audit-search tests).
+        retryUntilAsserted(() -> {
+            Column.updater(column5.getQualifiedName(), COLUMN_NAME5)
+                    .ownerGroup(ownerGroup.getName())
+                    .build()
+                    .save(client);
+            Column refreshed = Column.get(client, column5.getGuid(), false);
+            Set<String> groups = refreshed.getOwnerGroups();
+            assertNotNull(groups);
+            assertEquals(groups.size(), 1);
+            assertTrue(groups.contains(ownerGroup.getName()));
+            return refreshed;
+        });
     }
 
     @Test(


### PR DESCRIPTION
Proactive sweep for the two flakiness anti-patterns we've been fixing reactively (see #2640, #2642, #2646, #2647), applied to the remaining sites most likely to flake under tenant load. A full pass over ~200 `retrySearchUntil` sites found **3 real candidates**; the rest gate count then assert only identity (name/guid), which doesn't lag.

### Pattern A — count-gated retry, then assert lagging values
- **`CustomMetadataTest.readTermAuditByGuid` / `readTermAuditByQN`** — gated on a raw audit count (`14`) before `validateAudits` walks the full oldest→newest CM audit sequence. Spurious no-op audits can satisfy the count before the terminal CM audits are indexed, so the sequence assertion reads an incomplete stream. Now retries fetch-and-validate until the expected sequence is present (identical fix to `SQLAssetTest.searchAuditLogByGuid`).

### Pattern B1 — owner group asserted off the synchronous save response
- **`SQLAssetTest.updateColumnOwners`** — asserted the just-created group round-tripped off the save response, directly exposed to the MS-2016 owner-validation-cache silent drop that bit `SuggestionsTest.updateT1`. Now re-applies via write-retry until a read-back confirms it persisted. Bonus: this guarantees the "ownerGroups set" audit actually exists, which the downstream audit-search tests depend on.

### Sweep negatives (explicitly checked, nothing to do)
- **B2 (alias vs canonical group name):** no sites beyond the already-fixed `TableSearchTest` — every other owner-group site uses `group.getName()`.
- Package tests asserting struct/relationship/tag values already pass a `condition` predicate to `retrySearchUntil` (e.g. `S3WithPrefixesTest`, the delta RAB tests) — already robust.
- `SQLAssetTest.updateColumnOwnersX` (clearing owners) left as-is — clearing isn't exposed to the assignment race.

All test-side; reuses `AtlanLiveTest.retryUntilAsserted(...)`. Compiles + formatted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)